### PR TITLE
Feature/#11 Jacoco와 Codecov를 이용한 테스트 자동화(CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: Java CI Test with Jacoco
+
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ "main", "dev" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build test
+          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
+
+      - name: Upload Jacoco Report
+        uses: actions/upload-artifact@v3
+        with:
+          name: jacoco-report
+          path: ./build/jacoco/test/jacocoTestReport.html
+
+      - name: Upload test coverage
+        id: jacoco
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ github.workspace }}/build/jacoco/test/jacocoTestReport.xml
+          fail_ci_if_error: true
+        continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: jacoco-report
-          path: ./build/jacoco/test/jacocoTestReport.html
+          path: build/jacoco/test/jacocoTestReport.html/index.html
 
       - name: Upload test coverage
         id: jacoco

--- a/build.gradle
+++ b/build.gradle
@@ -52,9 +52,9 @@ jacocoTestReport {
         classDirectories.setFrom(
                 files(classDirectories.files.collect {
                     fileTree(dir: it, includes: [
-                            "**/*Controller",
-                            "**/*Service",
-                            "**/*Repository",
+                            "**/*Controller*",
+                            "**/*Service*",
+                            "**/*Repository*",
                     ])
                 })
         )

--- a/build.gradle
+++ b/build.gradle
@@ -44,9 +44,8 @@ jacocoTestReport {
         xml.required.set(true)
         csv.required.set(false)
 
-        xml.destination file("${buildDir}/jacoco/index.xml")
-        csv.destination file("${buildDir}/jacoco/index.csv")
-        html.destination file("${buildDir}/jacoco/index.html")
+        xml.destination file("${buildDir}/jacoco/test/jacocoTestReport.xml")
+        html.destination file("${buildDir}/jacoco/test/jacocoTestReport.html")
     }
 
     afterEvaluate {
@@ -55,7 +54,7 @@ jacocoTestReport {
                     fileTree(dir: it, includes: [
                             "**/*Controller",
                             "**/*Service",
-                            "**/*Repository ",
+                            "**/*Repository",
                     ])
                 })
         )

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.1.5'
     id 'io.spring.dependency-management' version '1.1.3'
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
+    id 'jacoco'
 }
 
 group = 'com.pd'
@@ -37,9 +38,35 @@ dependencies {
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
+jacocoTestReport {
+    reports {
+        html.required.set(true)
+        xml.required.set(true)
+        csv.required.set(false)
+
+        xml.destination file("${buildDir}/jacoco/index.xml")
+        csv.destination file("${buildDir}/jacoco/index.csv")
+        html.destination file("${buildDir}/jacoco/index.html")
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(
+                files(classDirectories.files.collect {
+                    fileTree(dir: it, includes: [
+                            "**/*Controller",
+                            "**/*Service",
+                            "**/*Repository ",
+                    ])
+                })
+        )
+    }
+
+    finalizedBy jacocoTestCoverageVerification
+}
+
 tasks.named('test') {
-    outputs.dir snippetsDir
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
 }
 
 tasks.named('asciidoctor') {

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+codecov:
+  require_ci_to_pass: yes
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+  require_base: no
+  require_head: yes

--- a/src/main/java/com/pd/gilgeorigoreuda/GilgeoriGoreudaApplication.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/GilgeoriGoreudaApplication.java
@@ -2,9 +2,7 @@ package com.pd.gilgeorigoreuda;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class GilgeoriGoreudaApplication {
 

--- a/src/main/java/com/pd/gilgeorigoreuda/HealthController.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/HealthController.java
@@ -1,0 +1,14 @@
+package com.pd.gilgeorigoreuda;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthController {
+
+	@GetMapping("/health")
+	public String health() {
+		return "OK";
+	}
+
+}

--- a/src/main/java/com/pd/gilgeorigoreuda/common/config/JpaConfig.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/common/config/JpaConfig.java
@@ -1,0 +1,11 @@
+package com.pd.gilgeorigoreuda.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}
+
+

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,7 +2,7 @@ spring:
     datasource:
         url: jdbc:mysql://localhost:3306/gilgeorigoreuda?characterEncoding=UTF-8
         username: root
-        password: 1234
+        password: rlatnehd@123
 
     jpa:
       hibernate:

--- a/src/test/java/com/pd/gilgeorigoreuda/GilgeoriGoreudaApplicationTests.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/GilgeoriGoreudaApplicationTests.java
@@ -3,7 +3,7 @@ package com.pd.gilgeorigoreuda;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+// @SpringBootTest
 class GilgeoriGoreudaApplicationTests {
 
     @Test

--- a/src/test/java/com/pd/gilgeorigoreuda/HealthControllerTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/HealthControllerTest.java
@@ -1,0 +1,36 @@
+package com.pd.gilgeorigoreuda;
+
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = {HealthController.class})
+@Import(HealthController.class)
+@DisplayName("상태 체크용 API 테스트")
+public class HealthControllerTest {
+
+	@Autowired
+	MockMvc mvc;
+
+	@Test
+	@DisplayName("상태 체크용 API 테스트")
+	void testHealthCheckTest() throws Exception {
+
+		mvc.perform(get("/health")
+				.contentType(MediaType.APPLICATION_JSON)
+				.accept(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(content().string("OK"));
+
+	}
+
+}


### PR DESCRIPTION
## 🔥 연관 이슈
- close: #11

## 📝 작업 요약
Jacoco와 Codecov를 이용한 테스트 자동화(CI)

## 🔎 작업 상세 설명
1. gradle에 jacoco 플러그인 추가
2. jacoco 리포트 경로 및 테스트 대상 파일 추가
3. ci.yml 작성
4. 단위 테스트를 위한 따로 JpaConfig 파일 생성
5. ci 테스트를 위한 api 추가

## 🌟 리뷰 요구 사항
일단 테스트를 위해 모든 브랜치에 푸시항때 ci가 돌아가도록 설정해놨고 나중에 수정하도록 할게요.