### PR TITLE
setting/#78 RestDocs 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    asciidoctorExt
 }
 
 repositories {
@@ -37,9 +38,11 @@ dependencies {
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 }
 
 jacocoTestReport {
@@ -69,10 +72,27 @@ jacocoTestReport {
 
 tasks.named('test') {
     useJUnitPlatform()
+    outputs.dir snippetsDir
     finalizedBy jacocoTestReport
 }
 
 tasks.named('asciidoctor') {
-    inputs.dir snippetsDir
     dependsOn test
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
+    baseDirFollowsSourceFile()
+}
+
+tasks.register('copyApiDocument', Copy) {
+    dependsOn asciidoctor
+    doFirst {
+        delete file("src/main/resources/static/docs") // 기존 문서 삭제
+    }
+
+    from asciidoctor.outputDir
+    into file("src/main/resources/static/docs")
+}
+
+build {
+    dependsOn copyApiDocument
 }

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,35 @@
+= gilgeori-goreuda
+:toc: left
+:source-highlighter: highlightjs
+:sectlinks:
+
+[[overview-http-status-codes]]
+=== HTTP status codes
+
+|===
+| 상태 코드 | 설명
+
+| `200 OK`
+| 성공
+
+| `201 Created`
+| 리소스 생성
+
+| `204 NO_CONTENT`
+| 성공 후 반환 값 없음
+
+| `400 Bad Request`
+| 잘못된 요청
+
+| `401 Unauthorized`
+| 비인증 상태
+
+| `403 Forbidden`
+| 권한 거부
+
+| `404 Not Found`
+| 존재하지 않는 요청 리소스
+
+| `500 Internal Server Error`
+| 서버 에러
+|===

--- a/src/test/java/com/pd/gilgeorigoreuda/home/controller/HomeControllerTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/home/controller/HomeControllerTest.java
@@ -2,6 +2,7 @@ package com.pd.gilgeorigoreuda.home.controller;
 
 import com.pd.gilgeorigoreuda.home.dto.response.PlaceListResponse;
 import com.pd.gilgeorigoreuda.home.dto.response.PlaceResponse;
+import com.pd.gilgeorigoreuda.home.service.HomeService;
 import com.pd.gilgeorigoreuda.settings.ControllerTest;
 import com.pd.gilgeorigoreuda.store.domain.entity.Store;
 import com.pd.gilgeorigoreuda.store.domain.entity.StreetAddress;
@@ -9,6 +10,7 @@ import com.pd.gilgeorigoreuda.store.domain.entity.StreetAddress;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -21,6 +23,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.hamcrest.Matchers.*;
 
 class HomeControllerTest extends ControllerTest {
+
+    @MockBean
+    private HomeService homeService;
 
     private List<Store> getMockStores() {
         List<Store> stores = new ArrayList<>();

--- a/src/test/java/com/pd/gilgeorigoreuda/settings/ControllerTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/settings/ControllerTest.java
@@ -3,22 +3,36 @@ package com.pd.gilgeorigoreuda.settings;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pd.gilgeorigoreuda.home.controller.HomeController;
 import com.pd.gilgeorigoreuda.home.service.HomeService;
+import com.pd.gilgeorigoreuda.settings.restdocs.RestDocsConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.pd.gilgeorigoreuda.review.controller.ReviewController;
 import com.pd.gilgeorigoreuda.store.controller.StoreController;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
 
-@AutoConfigureRestDocs
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+
 @WebMvcTest({
 //	ReviewController.class,
 //	StoreController.class,
 	HomeController.class
 })
+@Import(RestDocsConfiguration.class)
+@ExtendWith(RestDocumentationExtension.class)
+@MockBean(JpaMetamodelMappingContext.class)
 @ActiveProfiles("test")
 public abstract class ControllerTest {
 
@@ -26,9 +40,21 @@ public abstract class ControllerTest {
 	protected MockMvc mockMvc;
 
 	@Autowired
+	protected RestDocumentationResultHandler restDocs;
+
+	@Autowired
 	protected ObjectMapper objectMapper;
 
-	@MockBean
-	protected HomeService homeService;
+	@BeforeEach
+	void setUp(
+			final WebApplicationContext context,
+			final RestDocumentationContextProvider restDocumentation
+	) {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+				.apply(documentationConfiguration(restDocumentation))
+				.alwaysDo(restDocs)
+				.addFilters(new CharacterEncodingFilter("UTF-8", true))
+				.build();
+	}
 
 }

--- a/src/test/java/com/pd/gilgeorigoreuda/settings/restdocs/RestDocsConfiguration.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/settings/restdocs/RestDocsConfiguration.java
@@ -1,0 +1,33 @@
+package com.pd.gilgeorigoreuda.settings.restdocs;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.snippet.Attributes.*;
+
+@Configuration
+public class RestDocsConfiguration {
+
+    public static Attribute field(final String key, final String value) {
+        return new Attribute(key, value);
+    }
+
+    @Bean
+    public RestDocumentationResultHandler write() {
+        return document(
+                "{class-name}/{method-name}",
+                preprocessRequest(
+                        removeHeaders("Content-Length", "Host"),
+                        prettyPrint()
+                ),
+                preprocessResponse(
+                        removeHeaders("Transfer-Encoding", "Date", "Keep-Alive", "Connection"),
+                        prettyPrint()
+                )
+        );
+    }
+
+}

--- a/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,0 +1,10 @@
+|===
+|Path|Type|Description|Constraint
+
+{{#fields}}
+    |{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+    |{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+    |{{#tableCellContent}}{{description}}{{/tableCellContent}}
+    |{{#tableCellContent}}{{#constraint}}{{.}}{{/constraint}}{{/tableCellContent}}
+{{/fields}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/request-headers.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-headers.snippet
@@ -1,0 +1,9 @@
+|===
+|Name|Description|Constraint
+
+{{#headers}}
+    |{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+    |{{#tableCellContent}}{{description}}{{/tableCellContent}}
+    |{{#tableCellContent}}{{#constraint}}{{.}}{{/constraint}}{{/tableCellContent}}
+{{/headers}}
+|===


### PR DESCRIPTION
## 🔥 연관 이슈
- close: #78 

## 📝 작업 요약
api 문서화를 위한 rest docs 세팅

## 🔎 작업 상세 설명
1. 의존성 및 gradle 추가 설정
2. 1차 템플릿 작성 추후 수정 예정
3. ControllerTest 수정
4. RestDocsConfiguration 추가

## 🌟 리뷰 요구 사항
