### PR TITLE
feature/#89 cors origin 과 method 추가

### DIFF
--- a/src/main/java/com/pd/gilgeorigoreuda/common/config/web/CorsConfig.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/common/config/web/CorsConfig.java
@@ -1,0 +1,27 @@
+package com.pd.gilgeorigoreuda.common.config.web;
+
+import org.apache.http.HttpHeaders;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    // todo: 모든 출처 요청 허용 보안상 위험 -> 실제 운영 환경에서는 * 대신에 허용하려는 출처(도메인)를 명시
+    private static final String LOCALHOST_FRONTEND = "http://localhost:3000";
+    private static final String DEV_SERVER = "https://dev.gilgeorigoreuda.com";
+    private static final String PROD_SERVER = "https://gilgeorigoreuda.com";
+
+    @Override
+    public void addCorsMappings(final CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(PROD_SERVER, DEV_SERVER, LOCALHOST_FRONTEND)
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+                .allowCredentials(true)
+                .exposedHeaders(HttpHeaders.LOCATION);
+
+        WebMvcConfigurer.super.addCorsMappings(registry);
+    }
+
+}


### PR DESCRIPTION
## 🔥 연관 이슈
- close: #89 

## 📝 작업 요약
CORS 정책을 적용하기 위한 필터를 구현 -> CORS 관련 헤더를 설정하여, 다른 출처에서의 요청을 허용하도록 설정

## 🔎 작업 상세 설명
1. 로컬 프론트 origin 허용, 추후를 위한 dev, prod 도메인 origin 허용
2. PUT, POST, DELETE, GET, PATCH, OPTIONS 메소드 허용

## 🌟 리뷰 요구 사항

