### PR TITLE
refactor/#107 위경도 전체 자릿수와 소수점 자릿수 지정

### DIFF
--- a/src/main/java/com/pd/gilgeorigoreuda/store/domain/entity/Store.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/store/domain/entity/Store.java
@@ -78,10 +78,10 @@ public class Store extends BaseTimeEntity {
 	@Column(name = "image_url", length = 512)
 	private String imageUrl;
 
-	@Column(name = "lat", nullable = false)
+	@Column(name = "lat", precision = 22, scale = 16, nullable = false)
 	private BigDecimal lat;
 
-	@Column(name = "lng", nullable = false)
+	@Column(name = "lng", precision = 22, scale = 16, nullable = false)
 	private BigDecimal lng;
 
 	@Embedded


### PR DESCRIPTION
## 🔥 연관 이슈
- close: #107

## 📝 작업 요약
store의 위경도 타입을 BigDecimal의 정수,소숫점 자리수 변경

## 🔎 작업 상세 설명
precision, scale을 지정해주지 않아 소수점이 2자리까지만 저장되어 정확인 위경도값 도출 못해서
precision=22 scalse=16으로 지정

## 🌟 리뷰 요구 사항
바뀐 자료형 숙지해주세요!