### PR TITLE
refactor/#103 image upload 모듈화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.528'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     implementation 'com.google.code.gson:gson:2.8.7'
 

--- a/src/main/java/com/pd/gilgeorigoreuda/common/config/AsyncConfig.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/common/config/AsyncConfig.java
@@ -1,0 +1,29 @@
+package com.pd.gilgeorigoreuda.common.config;
+
+import com.pd.gilgeorigoreuda.common.decorater.MdcTaskDecorator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean
+    public TaskExecutor taskExecutor() {
+        ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+
+        taskExecutor.setCorePoolSize(8);
+        taskExecutor.setMaxPoolSize(50);
+        taskExecutor.setQueueCapacity(200);
+
+        taskExecutor.setTaskDecorator(new MdcTaskDecorator());
+        taskExecutor.setThreadNamePrefix("async-task-");
+        taskExecutor.setThreadGroupName("async-group");
+
+        return taskExecutor;
+    }
+
+}

--- a/src/main/java/com/pd/gilgeorigoreuda/common/config/S3Config.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/common/config/S3Config.java
@@ -3,6 +3,7 @@ package com.pd.gilgeorigoreuda.common.config;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
@@ -11,18 +12,27 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class S3Config {
-    @Value("${cloud.aws.credentials.access-key}")
-    private String accessKey;
-    @Value("${cloud.aws.credentials.secret-key}")
-    private String accessSecret;
+
+//    @Value("${cloud.aws.credentials.access-key}")
+//    private String accessKey;
+//    @Value("${cloud.aws.credentials.secret-key}")
+//    private String accessSecret;
     @Value("${cloud.aws.region.static}")
     private String region;
 
+//    @Bean
+//    public AmazonS3Client s3Client() {
+//        AWSCredentials credentials = new BasicAWSCredentials(accessKey, accessSecret);
+//        return (AmazonS3Client)AmazonS3ClientBuilder.standard()
+//                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+//                .withRegion(region).build();
+//    }
+
     @Bean
-    public AmazonS3Client s3Client() {
-        AWSCredentials credentials = new BasicAWSCredentials(accessKey, accessSecret);
-        return (AmazonS3Client)AmazonS3ClientBuilder.standard()
-                .withCredentials(new AWSStaticCredentialsProvider(credentials))
-                .withRegion(region).build();
+    public AmazonS3 S3Client() {
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .build();
     }
+
 }

--- a/src/main/java/com/pd/gilgeorigoreuda/common/config/S3Config.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/common/config/S3Config.java
@@ -1,10 +1,8 @@
 package com.pd.gilgeorigoreuda.common.config;
 
-import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -21,14 +19,6 @@ public class S3Config {
 
     @Value("${cloud.aws.region.static}")
     private String region;
-
-//    @Bean
-//    public AmazonS3Client s3Client() {
-//        AWSCredentials credentials = new BasicAWSCredentials(accessKey, accessSecret);
-//        return (AmazonS3Client)AmazonS3ClientBuilder.standard()
-//                .withCredentials(new AWSStaticCredentialsProvider(credentials))
-//                .withRegion(region).build();
-//    }
 
     @Bean
     public AmazonS3 S3Client() {

--- a/src/main/java/com/pd/gilgeorigoreuda/common/config/S3Config.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/common/config/S3Config.java
@@ -13,10 +13,12 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class S3Config {
 
-//    @Value("${cloud.aws.credentials.access-key}")
-//    private String accessKey;
-//    @Value("${cloud.aws.credentials.secret-key}")
-//    private String accessSecret;
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String accessSecret;
+
     @Value("${cloud.aws.region.static}")
     private String region;
 
@@ -30,8 +32,14 @@ public class S3Config {
 
     @Bean
     public AmazonS3 S3Client() {
-        return AmazonS3ClientBuilder.standard()
+        return AmazonS3ClientBuilder
+                .standard()
                 .withRegion(region)
+                .withCredentials(
+                        new AWSStaticCredentialsProvider(
+                                new BasicAWSCredentials(accessKey, accessSecret)
+                        )
+                )
                 .build();
     }
 

--- a/src/main/java/com/pd/gilgeorigoreuda/common/decorater/MdcTaskDecorator.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/common/decorater/MdcTaskDecorator.java
@@ -1,0 +1,22 @@
+package com.pd.gilgeorigoreuda.common.decorater;
+
+import org.slf4j.MDC;
+import org.springframework.core.task.TaskDecorator;
+
+import java.util.Map;
+
+public class MdcTaskDecorator implements TaskDecorator {
+
+    @Override
+    public Runnable decorate(Runnable task) {
+        Map<String, String> callerThreadContext = MDC.getCopyOfContextMap();
+        return () -> {
+            if(callerThreadContext != null){
+                MDC.setContextMap(callerThreadContext);
+            }
+
+            task.run();
+        };
+    }
+
+}

--- a/src/main/java/com/pd/gilgeorigoreuda/common/exception/ExceptionType.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/common/exception/ExceptionType.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.Objects;
 
 import com.pd.gilgeorigoreuda.auth.exception.EmailDuplicatedException;
+import com.pd.gilgeorigoreuda.image.exception.*;
 import com.pd.gilgeorigoreuda.store.exception.*;
 import com.pd.gilgeorigoreuda.visit.exception.NoSuchStoreVisitRecordException;
 import com.pd.gilgeorigoreuda.visit.exception.OutOfBoundaryException;
@@ -34,7 +35,16 @@ public enum ExceptionType {
 	NO_SUCH_STORE_VISIT_RECORD_EXCEPTION("S008", "존재하지 않는 가게 방문 기록입니다.", NoSuchStoreVisitRecordException.class),
 	TIME_OUT_EXCEPTION("S009", "인증 시간이 초과되었습니다. 2시간이 지난 방문 기록입니다.", TimeOutException.class),
 	TOO_LONG_DISTANCE_EXCEPTION("S010", "방문하기에 너무 먼 거리에 있습니다. 근처에 가서 다시 시도해주세요.", TooLongDistanceException.class),
-	LIMIT_DISTANCE_REPORT_EXCEPTION("S011", "신고하려는 가게와 사용자의 위치가 100m를 초과했습니다.", LimitDistanceReportException.class)
+	LIMIT_DISTANCE_REPORT_EXCEPTION("S011", "신고하려는 가게와 사용자의 위치가 100m를 초과했습니다.", LimitDistanceReportException.class),
+
+	IMAGE_NULL_EXCEPTION("I001", "업로드할 이미지 파일이 없습니다.", ImageNullException.class),
+	INVALID_IMAGE_PATH_EXCEPTION("I002", "이미지를 저장할 경로가 올바르지 않습니다.", InvalidImagePathException.class),
+	INVALID_IMAGE_URL_EXCEPTION("I003", "이미지 URL이 올바르지 않습니다.", InvalidImageUrlException.class),
+	INVALID_IMAGE_FILE_EXCEPTION("I004", "이미지 파일이 아닙니다.", InvalidImageFileException.class),
+	FILE_IMAGE_NAME_HASH_EXCEPTION("I005", "파일 이름을 해싱하는데 실패했습니다.", FileImageNameHashException.class),
+	EXCEED_IMAGE_CAPACITY_EXCEPTION("I006", "업로드 가능한 이미지 크기를 초과했습니다.", ExceedImageCapacityException.class),
+	EXCEED_IMAGE_LIST_SIZE_EXCEPTION("I006", "업로드 가능한 이미지 개수를 초과했습니다.", ExceedImageListSizeException.class),
+	EMPTY_IMAGE_LIST_EXCEPTION("I007", "최소 한 장 이상의 이미지를 업로드해야합니다.", EmptyImageListException.class),
 	;
 
 	private final String errorCode;

--- a/src/main/java/com/pd/gilgeorigoreuda/common/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/common/exception/GlobalControllerAdvice.java
@@ -1,5 +1,6 @@
 package com.pd.gilgeorigoreuda.common.exception;
 
+import org.apache.tomcat.util.http.fileupload.impl.SizeLimitExceededException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -38,7 +39,7 @@ public class GlobalControllerAdvice {
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	public ResponseEntity<ErrorResponse> methodArgumentNotValidException(MethodArgumentNotValidException e) {
-		log.info(String.format("MethodArgumentNotValidException : %s", e));
+		log.error(String.format("MethodArgumentNotValidException : %s", e));
 
 		FieldError firstFieldError = e.getFieldErrors().get(0);
 		String errorCode = firstFieldError.getCode();
@@ -47,6 +48,19 @@ public class GlobalControllerAdvice {
 
 		return ResponseEntity
 				.badRequest()
+				.body(new ErrorResponse(errorCode, errorMessage));
+	}
+
+	@ExceptionHandler(SizeLimitExceededException.class)
+	public ResponseEntity<ErrorResponse> handleSizeLimitExceededException(final SizeLimitExceededException e) {
+		log.warn(e.getMessage(), e);
+
+		String errorCode = ExceptionType.EXCEED_IMAGE_CAPACITY_EXCEPTION.getErrorCode();
+		String errorMessage = ExceptionType.EXCEED_IMAGE_CAPACITY_EXCEPTION.getErrorMessage()
+				+ " 입력된 이미지 용량은 " + e.getActualSize() + " byte 입니다. "
+				+ "(제한 용량: " + e.getPermittedSize() + " byte)";
+
+		return ResponseEntity.badRequest()
 				.body(new ErrorResponse(errorCode, errorMessage));
 	}
 

--- a/src/main/java/com/pd/gilgeorigoreuda/fileUpload/service/FileUploadService.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/fileUpload/service/FileUploadService.java
@@ -1,49 +1,49 @@
-package com.pd.gilgeorigoreuda.fileUpload.service;
-
-import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectRequest;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.server.ResponseStatusException;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-
-@RequiredArgsConstructor
-@Service
-public class FileUploadService {
-    private final UUID uuid = UUID.randomUUID();
-
-    private final AmazonS3Client amazonS3Client;
-
-    public List<String> fileUpload(final String bucket, final List<MultipartFile> files) {
-
-        List<String> filesName = new ArrayList<>();
-
-        files.forEach(file -> {
-            String fileName = uuid + file.getOriginalFilename();
-            ObjectMetadata objectMetadata = new ObjectMetadata();
-            objectMetadata.setContentLength(file.getSize());
-            objectMetadata.setContentType(file.getContentType());
-
-            try(InputStream inputStream = file.getInputStream()) {
-                amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata).withCannedAcl(CannedAccessControlList.PublicRead));
-            }
-            catch (IOException e) {
-                throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
-                        "업로드 에러");
-            }
-
-            filesName.add(amazonS3Client.getUrl(bucket, fileName).toString());
-
-        });
-        return filesName;
-    }
-}
+//package com.pd.gilgeorigoreuda.fileUpload.service;
+//
+//import com.amazonaws.services.s3.AmazonS3Client;
+//import com.amazonaws.services.s3.model.CannedAccessControlList;
+//import com.amazonaws.services.s3.model.ObjectMetadata;
+//import com.amazonaws.services.s3.model.PutObjectRequest;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.http.HttpStatus;
+//import org.springframework.stereotype.Service;
+//import org.springframework.web.multipart.MultipartFile;
+//import org.springframework.web.server.ResponseStatusException;
+//
+//import java.io.IOException;
+//import java.io.InputStream;
+//import java.util.ArrayList;
+//import java.util.List;
+//import java.util.UUID;
+//
+//@RequiredArgsConstructor
+//@Service
+//public class FileUploadService {
+//    private final UUID uuid = UUID.randomUUID();
+//
+//    private final AmazonS3Client amazonS3Client;
+//
+//    public List<String> fileUpload(final String bucket, final List<MultipartFile> files) {
+//
+//        List<String> filesName = new ArrayList<>();
+//
+//        files.forEach(file -> {
+//            String fileName = uuid + file.getOriginalFilename();
+//            ObjectMetadata objectMetadata = new ObjectMetadata();
+//            objectMetadata.setContentLength(file.getSize());
+//            objectMetadata.setContentType(file.getContentType());
+//
+//            try(InputStream inputStream = file.getInputStream()) {
+//                amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata).withCannedAcl(CannedAccessControlList.PublicRead));
+//            }
+//            catch (IOException e) {
+//                throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+//                        "업로드 에러");
+//            }
+//
+//            filesName.add(amazonS3Client.getUrl(bucket, fileName).toString());
+//
+//        });
+//        return filesName;
+//    }
+//}

--- a/src/main/java/com/pd/gilgeorigoreuda/image/ImageFile.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/image/ImageFile.java
@@ -1,0 +1,69 @@
+package com.pd.gilgeorigoreuda.image;
+
+import com.pd.gilgeorigoreuda.image.exception.FileImageNameHashException;
+import com.pd.gilgeorigoreuda.image.exception.ImageNullException;
+import lombok.Getter;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@Getter
+public class ImageFile {
+
+    private static final String EXTENSION_DELIMITER = ".";
+
+    private final MultipartFile file;
+    private final String hashedName;
+
+    public ImageFile(final MultipartFile file) {
+        validateNullImage(file);
+        this.file = file;
+        this.hashedName = hashName(file);
+    }
+
+    private void validateNullImage(final MultipartFile file) {
+        if (file.isEmpty()) {
+            throw new ImageNullException();
+        }
+    }
+
+    private String hashName(final MultipartFile image) {
+        final String name = image.getOriginalFilename();
+        final String filenameExtension = EXTENSION_DELIMITER + StringUtils.getFilenameExtension(name);
+        final String nameAndDate = name + LocalDateTime.now();
+        try {
+            final MessageDigest hashAlgorithm = MessageDigest.getInstance("SHA3-256");
+            final byte[] hashBytes = hashAlgorithm.digest(nameAndDate.getBytes(StandardCharsets.UTF_8));
+            return bytesToHex(hashBytes) + filenameExtension;
+        } catch (final NoSuchAlgorithmException e) {
+            throw new FileImageNameHashException();
+        }
+    }
+
+    private String bytesToHex(final byte[] bytes) {
+        return IntStream.range(0, bytes.length)
+                .mapToObj(i -> String.format("%02x", bytes[i] & 0xff))
+                .collect(Collectors.joining());
+    }
+
+    public String getContentType() {
+        return this.file.getContentType();
+    }
+
+    public long getSize() {
+        return this.file.getSize();
+    }
+
+    public InputStream getInputStream() throws IOException {
+        return this.file.getInputStream();
+    }
+
+}

--- a/src/main/java/com/pd/gilgeorigoreuda/image/ImageUploader.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/image/ImageUploader.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.pd.gilgeorigoreuda.image.exception.InvalidImageFileException;
 import com.pd.gilgeorigoreuda.image.exception.InvalidImagePathException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -14,6 +15,7 @@ import java.io.InputStream;
 import java.util.List;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class ImageUploader {
 
@@ -43,9 +45,11 @@ public class ImageUploader {
 
         try (final InputStream inputStream = imageFile.getInputStream()) {
             s3Client.putObject(bucket, path, inputStream, metadata);
-        } catch (final AmazonServiceException e) {
+        } catch (AmazonServiceException e) {
+            log.error("AmazonServiceException: {}", e.getMessage());
             throw new InvalidImagePathException();
-        } catch (final IOException e) {
+        } catch (IOException e) {
+            log.error("AmazonServiceException: {}", e.getMessage());
             throw new InvalidImageFileException();
         }
         return imageFile.getHashedName();

--- a/src/main/java/com/pd/gilgeorigoreuda/image/ImageUploader.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/image/ImageUploader.java
@@ -1,0 +1,54 @@
+package com.pd.gilgeorigoreuda.image;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.pd.gilgeorigoreuda.image.exception.InvalidImageFileException;
+import com.pd.gilgeorigoreuda.image.exception.InvalidImagePathException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ImageUploader {
+
+    private static final String CACHE_CONTROL_VALUE = "max-age=3153600";
+
+    private final AmazonS3 s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.s3.folder}")
+    private String folder;
+
+    public List<String> uploadImages(final List<ImageFile> imageFiles) {
+        return imageFiles.stream()
+                .map(this::uploadImage)
+                .toList();
+    }
+
+    private String uploadImage(final ImageFile imageFile) {
+        final String path = folder + imageFile.getHashedName();
+
+        final ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(imageFile.getContentType());
+        metadata.setContentLength(imageFile.getSize());
+        metadata.setCacheControl(CACHE_CONTROL_VALUE);
+
+        try (final InputStream inputStream = imageFile.getInputStream()) {
+            s3Client.putObject(bucket, path, inputStream, metadata);
+        } catch (final AmazonServiceException e) {
+            throw new InvalidImagePathException();
+        } catch (final IOException e) {
+            throw new InvalidImageFileException();
+        }
+        return imageFile.getHashedName();
+    }
+
+}

--- a/src/main/java/com/pd/gilgeorigoreuda/image/ImageUploader.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/image/ImageUploader.java
@@ -3,6 +3,7 @@ package com.pd.gilgeorigoreuda.image;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.pd.gilgeorigoreuda.image.domain.ImageFile;
 import com.pd.gilgeorigoreuda.image.exception.InvalidImageFileException;
 import com.pd.gilgeorigoreuda.image.exception.InvalidImagePathException;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/pd/gilgeorigoreuda/image/contorller/ImageController.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/image/contorller/ImageController.java
@@ -24,10 +24,7 @@ public class ImageController {
     public ResponseEntity<ImagesResponse> uploadImages(@RequestPart final List<MultipartFile> images) {
         final ImagesResponse imagesResponse = imageService.save(images);
 
-        final String firstImageName = imagesResponse.getImageNames()
-                .stream()
-                .findFirst()
-                .toString();
+        final String firstImageName = imagesResponse.getImageNames().get(0);
 
         return ResponseEntity
                 .created(URI.create(firstImageName))

--- a/src/main/java/com/pd/gilgeorigoreuda/image/contorller/ImageController.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/image/contorller/ImageController.java
@@ -1,0 +1,37 @@
+package com.pd.gilgeorigoreuda.image.contorller;
+
+import com.pd.gilgeorigoreuda.image.dto.response.ImagesResponse;
+import com.pd.gilgeorigoreuda.image.service.ImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/images")
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @PostMapping
+    public ResponseEntity<ImagesResponse> uploadImages(@RequestPart final List<MultipartFile> images) {
+        final ImagesResponse imagesResponse = imageService.save(images);
+
+        final String firstImageName = imagesResponse.getImageNames()
+                .stream()
+                .findFirst()
+                .toString();
+
+        return ResponseEntity
+                .created(URI.create(firstImageName))
+                .body(imagesResponse);
+    }
+
+}

--- a/src/main/java/com/pd/gilgeorigoreuda/image/domain/ImageFile.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/image/domain/ImageFile.java
@@ -1,4 +1,4 @@
-package com.pd.gilgeorigoreuda.image;
+package com.pd.gilgeorigoreuda.image.domain;
 
 import com.pd.gilgeorigoreuda.image.exception.FileImageNameHashException;
 import com.pd.gilgeorigoreuda.image.exception.ImageNullException;

--- a/src/main/java/com/pd/gilgeorigoreuda/image/domain/S3ImageDeleteEvent.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/image/domain/S3ImageDeleteEvent.java
@@ -1,0 +1,12 @@
+package com.pd.gilgeorigoreuda.image.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class S3ImageDeleteEvent {
+
+    private final String imageName;
+
+}

--- a/src/main/java/com/pd/gilgeorigoreuda/image/dto/response/ImagesResponse.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/image/dto/response/ImagesResponse.java
@@ -1,0 +1,18 @@
+package com.pd.gilgeorigoreuda.image.dto.response;
+;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ImagesResponse {
+
+    private List<String> imageNames;
+
+    public ImagesResponse(final List<String> imageNames) {
+        this.imageNames = imageNames;
+    }
+
+}

--- a/src/main/java/com/pd/gilgeorigoreuda/image/exception/EmptyImageListException.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/image/exception/EmptyImageListException.java
@@ -1,0 +1,10 @@
+package com.pd.gilgeorigoreuda.image.exception;
+
+import com.pd.gilgeorigoreuda.common.exception.GilgeorigoreudaException;
+import org.springframework.http.HttpStatus;
+
+public class EmptyImageListException extends GilgeorigoreudaException {
+    public EmptyImageListException() {
+        super(HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/pd/gilgeorigoreuda/image/exception/ExceedImageCapacityException.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/image/exception/ExceedImageCapacityException.java
@@ -1,0 +1,10 @@
+package com.pd.gilgeorigoreuda.image.exception;
+
+import com.pd.gilgeorigoreuda.common.exception.GilgeorigoreudaException;
+import org.springframework.http.HttpStatus;
+
+public class ExceedImageCapacityException extends GilgeorigoreudaException {
+    public ExceedImageCapacityException() {
+        super(HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/pd/gilgeorigoreuda/image/exception/ExceedImageListSizeException.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/image/exception/ExceedImageListSizeException.java
@@ -1,0 +1,10 @@
+package com.pd.gilgeorigoreuda.image.exception;
+
+import com.pd.gilgeorigoreuda.common.exception.GilgeorigoreudaException;
+import org.springframework.http.HttpStatus;
+
+public class ExceedImageListSizeException extends GilgeorigoreudaException {
+    public ExceedImageListSizeException() {
+        super(HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/pd/gilgeorigoreuda/image/exception/FileImageNameHashException.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/image/exception/FileImageNameHashException.java
@@ -1,0 +1,10 @@
+package com.pd.gilgeorigoreuda.image.exception;
+
+import com.pd.gilgeorigoreuda.common.exception.GilgeorigoreudaException;
+import org.springframework.http.HttpStatus;
+
+public class FileImageNameHashException extends GilgeorigoreudaException {
+    public FileImageNameHashException() {
+        super(HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/pd/gilgeorigoreuda/image/exception/ImageNullException.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/image/exception/ImageNullException.java
@@ -1,0 +1,10 @@
+package com.pd.gilgeorigoreuda.image.exception;
+
+import com.pd.gilgeorigoreuda.common.exception.GilgeorigoreudaException;
+import org.springframework.http.HttpStatus;
+
+public class ImageNullException extends GilgeorigoreudaException {
+    public ImageNullException() {
+        super(HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/pd/gilgeorigoreuda/image/exception/InvalidImageFileException.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/image/exception/InvalidImageFileException.java
@@ -1,0 +1,10 @@
+package com.pd.gilgeorigoreuda.image.exception;
+
+import com.pd.gilgeorigoreuda.common.exception.GilgeorigoreudaException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidImageFileException extends GilgeorigoreudaException {
+    public InvalidImageFileException() {
+        super(HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/pd/gilgeorigoreuda/image/exception/InvalidImagePathException.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/image/exception/InvalidImagePathException.java
@@ -1,0 +1,10 @@
+package com.pd.gilgeorigoreuda.image.exception;
+
+import com.pd.gilgeorigoreuda.common.exception.GilgeorigoreudaException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidImagePathException extends GilgeorigoreudaException {
+    public InvalidImagePathException() {
+        super(HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/pd/gilgeorigoreuda/image/exception/InvalidImageUrlException.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/image/exception/InvalidImageUrlException.java
@@ -1,0 +1,10 @@
+package com.pd.gilgeorigoreuda.image.exception;
+
+import com.pd.gilgeorigoreuda.common.exception.GilgeorigoreudaException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidImageUrlException extends GilgeorigoreudaException {
+    public InvalidImageUrlException() {
+        super(HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/pd/gilgeorigoreuda/image/listener/S3ImageDeleteEventListener.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/image/listener/S3ImageDeleteEventListener.java
@@ -1,0 +1,34 @@
+package com.pd.gilgeorigoreuda.image.listener;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.pd.gilgeorigoreuda.image.domain.S3ImageDeleteEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class S3ImageDeleteEventListener {
+
+    private final AmazonS3 s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.s3.folder}")
+    private String folder;
+
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(fallbackExecution = true)
+    public void deleteImageFileInS3(final S3ImageDeleteEvent event) {
+        String imageName = event.getImageName();
+
+        s3Client.deleteObject(bucket, folder + imageName);
+    }
+
+}

--- a/src/main/java/com/pd/gilgeorigoreuda/image/service/ImageService.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/image/service/ImageService.java
@@ -1,12 +1,11 @@
 package com.pd.gilgeorigoreuda.image.service;
 
-import com.pd.gilgeorigoreuda.image.ImageFile;
+import com.pd.gilgeorigoreuda.image.domain.ImageFile;
 import com.pd.gilgeorigoreuda.image.ImageUploader;
 import com.pd.gilgeorigoreuda.image.dto.response.ImagesResponse;
 import com.pd.gilgeorigoreuda.image.exception.EmptyImageListException;
 import com.pd.gilgeorigoreuda.image.exception.ExceedImageListSizeException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 

--- a/src/main/java/com/pd/gilgeorigoreuda/image/service/ImageService.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/image/service/ImageService.java
@@ -1,0 +1,54 @@
+package com.pd.gilgeorigoreuda.image.service;
+
+import com.pd.gilgeorigoreuda.image.ImageFile;
+import com.pd.gilgeorigoreuda.image.ImageUploader;
+import com.pd.gilgeorigoreuda.image.dto.response.ImagesResponse;
+import com.pd.gilgeorigoreuda.image.exception.EmptyImageListException;
+import com.pd.gilgeorigoreuda.image.exception.ExceedImageListSizeException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private static final int MAX_IMAGE_LIST_SIZE = 5;
+    private static final int EMPTY_LIST_SIZE = 0;
+
+    private final ImageUploader imageUploader;
+//    private final ApplicationEventPublisher publisher;
+
+    public ImagesResponse save(final List<MultipartFile> images) {
+        validateSizeOfImages(images);
+
+        final List<ImageFile> imageFiles = images.stream()
+                .map(ImageFile::new)
+                .toList();
+        final List<String> imageNames = uploadImages(imageFiles);
+
+        return new ImagesResponse(imageNames);
+    }
+
+    private List<String> uploadImages(final List<ImageFile> imageFiles) {
+        return imageUploader.uploadImages(imageFiles);
+//        try {
+//            return imageUploader.uploadImages(imageFiles);
+//        } catch (final ImageException e) {
+//            imageFiles.forEach(imageFile -> publisher.publishEvent(new S3ImageEvent(imageFile.getHashedName())));
+//            throw e;
+//        }
+    }
+
+    private void validateSizeOfImages(final List<MultipartFile> images) {
+        if (images.size() > MAX_IMAGE_LIST_SIZE) {
+            throw new ExceedImageListSizeException();
+        }
+        if (images.size() == EMPTY_LIST_SIZE) {
+            throw new EmptyImageListException();
+        }
+    }
+}

--- a/src/main/java/com/pd/gilgeorigoreuda/review/service/ReviewService.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/review/service/ReviewService.java
@@ -1,6 +1,5 @@
 package com.pd.gilgeorigoreuda.review.service;
 
-import com.pd.gilgeorigoreuda.fileUpload.service.FileUploadService;
 import com.pd.gilgeorigoreuda.member.domain.entity.Member;
 import com.pd.gilgeorigoreuda.review.domain.entity.Review;
 import com.pd.gilgeorigoreuda.review.domain.entity.ReviewImage;
@@ -19,11 +18,11 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class ReviewService {
+public class  ReviewService {
 
     private final ReviewRepository reviewRepository;
     private final ReviewImageRepository reviewImageRepository;
-    private final FileUploadService fileUploadService;
+//    private final FileUploadService fileUploadService;
 
     @Value("g-reviewimages")
     private String bucket;
@@ -43,16 +42,16 @@ public class ReviewService {
 
         Review savedReview = reviewRepository.save(review);
 
-        List<String> fileNames = fileUploadService.fileUpload(bucket, files);
+//        List<String> fileNames = fileUploadService.fileUpload(bucket, files);
 
-        fileNames.forEach(name -> {
-            reviewImageRepository.save(
-                    ReviewImage
-                        .builder()
-                        .imageUrl(name)
-                        .review(Review.builder().id(savedReview.getId()).build())
-                        .build());
-        });
+//        fileNames.forEach(name -> {
+//            reviewImageRepository.save(
+//                    ReviewImage
+//                        .builder()
+//                        .imageUrl(name)
+//                        .review(Review.builder().id(savedReview.getId()).build())
+//                        .build());
+//        });
 
     }
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,8 +1,8 @@
 spring:
     datasource:
-        url: jdbc:mysql://localhost:3306/gilgeorigoreuda?characterEncoding=UTF-8
+        url: jdbc:mysql://34.64.193.39:3306/gilgeorigoreuda?characterEncoding=UTF-8
         username: root
-        password: 1q2w3e4r!!
+        password: rlatnehd@123
 
     jpa:
       hibernate:
@@ -15,10 +15,13 @@ spring:
 
 cloud:
   aws:
-    credentials:
-      accessKey: AKIAYEKHUA7HVZMVYI7T
-      secretKey: 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
+    #    credentials:
+    #      accessKey: AKIAYEKHUA7HVZMVYI7T
+    #      secretKey: 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
     region:
       static: ap-northeast-2
     stack:
       auto: false
+    s3:
+      bucket: gilgeorigoreuda
+      folder: dev

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -15,13 +15,13 @@ spring:
 
 cloud:
   aws:
-    #    credentials:
-    #      accessKey: AKIAYEKHUA7HVZMVYI7T
-    #      secretKey: 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
+    credentials:
+      accessKey: AKIAYEKHUA7HSDWVE5HD
+      secretKey: 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
     region:
       static: ap-northeast-2
     stack:
       auto: false
     s3:
       bucket: gilgeorigoreuda
-      folder: dev
+      folder: dev/


### PR DESCRIPTION
## 🔥 연관 이슈
- close: #103 

## 📝 작업 요약
image upload 모듈화

## 🔎 작업 상세 설명
이미지 업로드가 필요한 서비스마다 이미지를 업로드하는 중복 로직을 제거하고 
클라이언트가 이미지를 업로드하는 순간 image가 s3에 저정되고 이미지 파일명을 반환하고 그 반환된 파일명으로 이미지 url을 
리뷰, 가게, 프로필 등을 등록할때 직접 url을 요청 보내도록 수정

## 🌟 리뷰 요구 사항
