### PR TITLE
bug/#192 docker image platform 변경

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -53,7 +53,6 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          platforms: linux/arm64
           tags: sudongk/gilgeorigoreuda-dev:latest
           labels: ${{ steps.meta.outputs.labels }}
 


### PR DESCRIPTION
## 🔥 연관 이슈
- close: #192 

## 📝 작업 요약
docker image platform 변경

## 🔎 작업 상세 설명
ec2 플랫폼과 docker 이미지의 플랫폼이 일치하지 않아 컨테이너 실행 불가 문제 해결

## 🌟 리뷰 요구 사항

