### PR TITLE
feature/#347 가게 정보 업데이트시 가게 카테고리 및 이미지 변경 단위 테스트

### DIFF
--- a/src/main/java/com/pd/gilgeorigoreuda/store/domain/entity/Store.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/store/domain/entity/Store.java
@@ -9,6 +9,7 @@ import com.pd.gilgeorigoreuda.common.entity.BaseTimeEntity;
 import com.pd.gilgeorigoreuda.member.domain.entity.Member;
 import com.pd.gilgeorigoreuda.store.dto.request.BusinessDateRequest;
 
+import com.pd.gilgeorigoreuda.store.dto.request.StoreUpdateRequest;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -122,28 +123,17 @@ public class Store extends BaseTimeEntity {
 		}
 	}
 
-	public void updateStoreInfo(
-			final String name,
-			final String storeType,
-			final LocalTime openTime,
-			final LocalTime closeTime,
-			final String purchaseType,
-			final String businessDates,
-			final String imageUrl,
-			final BigDecimal lat,
-			final BigDecimal lng,
-			final String streetAddress,
-			final String lastModifiedMemberNickname) {
-		this.name = name;
-		this.storeType = StoreType.of(storeType);
-		this.openTime = openTime;
-		this.closeTime = closeTime;
-		this.purchaseType = PurchaseType.of(purchaseType);
-		this.businessDate = BusinessDateRequest.of(businessDates).toString();
-		this.imageUrl = imageUrl;
-		this.lat = lat;
-		this.lng = lng;
-		this.streetAddress = StreetAddress.of(streetAddress);
+	public void updateStoreInfo(final StoreUpdateRequest storeUpdateRequest, final String lastModifiedMemberNickname) {
+		this.name = storeUpdateRequest.getName();
+		this.storeType = StoreType.of(storeUpdateRequest.getStoreType());
+		this.openTime = storeUpdateRequest.getOpenTime();
+		this.closeTime = storeUpdateRequest.getCloseTime();
+		this.purchaseType = PurchaseType.of(storeUpdateRequest.getPurchaseType());
+		this.businessDate = BusinessDateRequest.of(storeUpdateRequest.getBusinessDates()).toString();
+		this.imageUrl = storeUpdateRequest.getImageUrl();
+		this.lat = storeUpdateRequest.getLat();
+		this.lng = storeUpdateRequest.getLng();
+		this.streetAddress = StreetAddress.of(storeUpdateRequest.getStreetAddress());
 		this.lastModifiedMemberNickname = lastModifiedMemberNickname;
 	}
 

--- a/src/main/java/com/pd/gilgeorigoreuda/store/service/StoreService.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/store/service/StoreService.java
@@ -77,20 +77,7 @@ public class StoreService {
 
 		List<FoodCategory> foodCategories = storeUpdateRequest.getFoodCategories().toEntities();
 
-		storeForUpdate.updateStoreInfo(
-				storeUpdateRequest.getName(),
-				storeUpdateRequest.getStoreType(),
-				storeUpdateRequest.getOpenTime(),
-				storeUpdateRequest.getCloseTime(),
-				storeUpdateRequest.getPurchaseType(),
-				storeUpdateRequest.getBusinessDates(),
-				storeUpdateRequest.getImageUrl(),
-				storeUpdateRequest.getLat(),
-				storeUpdateRequest.getLng(),
-				storeUpdateRequest.getStreetAddress(),
-				member.getNickname()
-		);
-
+		storeForUpdate.updateStoreInfo(storeUpdateRequest, member.getNickname());
 		storeForUpdate.addFoodCategories(foodCategories);
 
 		storeRepository.save(storeForUpdate);

--- a/src/test/java/com/pd/gilgeorigoreuda/settings/ServiceTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/settings/ServiceTest.java
@@ -3,10 +3,7 @@ package com.pd.gilgeorigoreuda.settings;
 import com.pd.gilgeorigoreuda.image.service.ImageService;
 import com.pd.gilgeorigoreuda.member.domain.entity.Member;
 import com.pd.gilgeorigoreuda.member.repository.MemberRepository;
-import com.pd.gilgeorigoreuda.store.domain.entity.PurchaseType;
-import com.pd.gilgeorigoreuda.store.domain.entity.Store;
-import com.pd.gilgeorigoreuda.store.domain.entity.StoreType;
-import com.pd.gilgeorigoreuda.store.domain.entity.StreetAddress;
+import com.pd.gilgeorigoreuda.store.domain.entity.*;
 import com.pd.gilgeorigoreuda.store.dto.request.BusinessDateRequest;
 import com.pd.gilgeorigoreuda.store.repository.StoreNativeQueryRepository;
 import com.pd.gilgeorigoreuda.store.repository.StoreRepository;
@@ -14,11 +11,14 @@ import com.pd.gilgeorigoreuda.store.service.StoreService;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @MockitoSettings
 @Transactional
@@ -31,6 +31,9 @@ public abstract class ServiceTest {
 
     // Mock 객체
     @Mock
+    protected ApplicationEventPublisher publisher;
+
+    @Mock
     protected StoreRepository storeRepository;
 
     @Mock
@@ -42,11 +45,22 @@ public abstract class ServiceTest {
     @Mock
     protected ImageService imageService;
 
+
     protected static final Member MEMBER = Member.builder()
             .id(1L)
             .nickname("nickname")
             .profileImageUrl("profileImageUrl")
             .socialId("socialId")
+            .build();
+
+    protected static final FoodCategory FOOD_CATEGORY1 = FoodCategory.builder()
+            .id(1L)
+            .foodType(FoodType.of("붕어빵"))
+            .build();
+
+    protected static final FoodCategory FOOD_CATEGORY2 = FoodCategory.builder()
+            .id(1L)
+            .foodType(FoodType.of("호떡"))
             .build();
 
     protected static final Store STORE = Store.builder()
@@ -62,6 +76,7 @@ public abstract class ServiceTest {
             .lng(BigDecimal.valueOf(127.123456))
             .streetAddress(StreetAddress.of("서울특별시 강남구 언주로1"))
             .member(MEMBER)
+            .foodCategories(new ArrayList<>(List.of(FOOD_CATEGORY1, FOOD_CATEGORY2)))
             .build();
 
 }

--- a/src/test/java/com/pd/gilgeorigoreuda/store/service/StoreServiceTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/store/service/StoreServiceTest.java
@@ -1,6 +1,7 @@
 package com.pd.gilgeorigoreuda.store.service;
 
-import com.pd.gilgeorigoreuda.common.util.DistanceCalculator;
+import com.pd.gilgeorigoreuda.image.domain.S3ImageDeleteEvent;
+import com.pd.gilgeorigoreuda.member.domain.entity.Member;
 import com.pd.gilgeorigoreuda.member.exception.NoSuchMemberException;
 import com.pd.gilgeorigoreuda.settings.ServiceTest;
 import com.pd.gilgeorigoreuda.store.domain.entity.*;
@@ -11,7 +12,9 @@ import com.pd.gilgeorigoreuda.store.dto.response.StoreCreateResponse;
 import com.pd.gilgeorigoreuda.store.dto.response.StoreResponse;
 import com.pd.gilgeorigoreuda.store.exception.AlreadyExistInBoundaryException;
 import com.pd.gilgeorigoreuda.store.exception.NoSuchStoreException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -20,6 +23,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.SoftAssertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
@@ -88,11 +92,11 @@ class StoreServiceTest extends ServiceTest {
                 () -> then(storeRepository).should(times(1)).save(any(Store.class)),
                 () -> then(storeNativeQueryRepository).should(times(1))
                         .isAlreadyExistInBoundary(
-                            storeCreateRequest.getLat(),
-                            storeCreateRequest.getLng(),
-                            streetAddress.getLargeAddress(),
-                            streetAddress.getMediumAddress(),
-                            TEST_BOUNDARY
+                                storeCreateRequest.getLat(),
+                                storeCreateRequest.getLng(),
+                                streetAddress.getLargeAddress(),
+                                streetAddress.getMediumAddress(),
+                                TEST_BOUNDARY
                         )
         );
     }
@@ -154,7 +158,7 @@ class StoreServiceTest extends ServiceTest {
     }
 
     @Test
-    @DisplayName("유효하지 않은 가게 id로 가게 정보 업데이트 호출 시 예외가 발생한다.")
+    @DisplayName("유효하지 않은 가게 id로 가게 정보 업데이트 호출 시 예외가 발생")
     void shouldThrowExceptionWhenStoreIdIsInvalid() {
         // given
         StoreUpdateRequest storeUpdateRequest = makeStoreUpdateRequest();
@@ -172,7 +176,7 @@ class StoreServiceTest extends ServiceTest {
     }
 
     @Test
-    @DisplayName("유효하지 않은 회원 id로 가게 정보 업데이트 호출 시 예외가 발생한다.")
+    @DisplayName("유효하지 않은 회원 id로 가게 정보 업데이트 호출 시 예외가 발생")
     void shouldThrowExceptionWhenMemberIdIsInvalid() {
         // given
         StoreUpdateRequest storeUpdateRequest = makeStoreUpdateRequest();
@@ -193,7 +197,7 @@ class StoreServiceTest extends ServiceTest {
     }
 
     @Test
-    @DisplayName("storeId에 해당하는 Store 정보와 거리 정보를 반환한다.")
+    @DisplayName("storeId에 해당하는 Store 정보 반환")
     void getStoreSuccess() {
         // given
         given(storeRepository.findStoreWithMemberAndCategories(ServiceTest.STORE.getId()))
@@ -208,7 +212,7 @@ class StoreServiceTest extends ServiceTest {
     }
 
     @Test
-    @DisplayName("유효하지 않는 id로 가게 조회시 예외가 발생한다.")
+    @DisplayName("유효하지 않는 id로 가게 조회시 예외가 발생")
     void shouldThrowExceptionWhenStoreIdInvalid() {
         // given
         given(storeRepository.findStoreWithMemberAndCategories(anyLong()))
@@ -219,6 +223,156 @@ class StoreServiceTest extends ServiceTest {
                 .isInstanceOf(NoSuchStoreException.class)
                 .extracting("errorCode")
                 .isEqualTo("S001");
+    }
+
+    @Nested
+    @DisplayName("가게 정보 변경 시 카테고리, 이미지 업데이트 테스트")
+    class UpdateStoreInfo {
+
+        private final Member member = ServiceTest.MEMBER;
+        private final Store store = ServiceTest.STORE;
+        private StoreUpdateRequest newImageRequest;
+        private StoreUpdateRequest sameImageRequest;
+        private StoreUpdateRequest newCategoryRequest;
+
+        private StoreUpdateRequest makeNewImageStoreUpdateRequest() {
+            return new StoreUpdateRequest(
+                    "수정된 붕어빵 가게",
+                    "포장마차",
+                    LocalTime.of(10, 0),
+                    LocalTime.of(22, 30),
+                    "현금",
+                    "https://newImage.com",
+                    "monday,tuesday,wednesday,thursday,friday,saturday,sunday",
+                    BigDecimal.valueOf(37.123456),
+                    BigDecimal.valueOf(127.123456),
+                    "서울특별시 강남구 언주로1",
+                    new FoodCategoryRequest(List.of("붕어빵", "호떡"))
+            );
+        }
+
+        private StoreUpdateRequest makeSameImageStoreUpdateRequest() {
+            return new StoreUpdateRequest(
+                    "수정된 붕어빵 가게",
+                    "포장마차",
+                    LocalTime.of(10, 0),
+                    LocalTime.of(22, 30),
+                    "현금",
+                    "https://image.com",
+                    "monday,tuesday,wednesday,thursday,friday,saturday,sunday",
+                    BigDecimal.valueOf(37.123456),
+                    BigDecimal.valueOf(127.123456),
+                    "서울특별시 강남구 언주로1",
+                    new FoodCategoryRequest(List.of("붕어빵", "호떡"))
+            );
+        }
+
+        private StoreUpdateRequest makeNewCategoryStoreUpdateRequest() {
+            return new StoreUpdateRequest(
+                    "수정된 붕어빵 가게",
+                    "포장마차",
+                    LocalTime.of(10, 0),
+                    LocalTime.of(22, 30),
+                    "현금",
+                    "https://image.com",
+                    "monday,tuesday,wednesday,thursday,friday,saturday,sunday",
+                    BigDecimal.valueOf(37.123456),
+                    BigDecimal.valueOf(127.123456),
+                    "서울특별시 강남구 언주로1",
+                    new FoodCategoryRequest(List.of("오뎅", "타코야끼"))
+            );
+        }
+
+        @BeforeEach
+        void setUp() {
+            newImageRequest = makeNewImageStoreUpdateRequest();
+            sameImageRequest = makeSameImageStoreUpdateRequest();
+            newCategoryRequest = makeNewCategoryStoreUpdateRequest();
+        }
+
+        @Test
+        @DisplayName("이미지가 변경되었을 경우 기존 이미지 삭제")
+        void deleteOriginalImageWhenImageIsChanged() {
+            // given
+            given(storeRepository.findStoreWithMemberAndCategories(anyLong()))
+                    .willReturn(Optional.of(store));
+
+            given(memberRepository.findById(anyLong()))
+                    .willReturn(Optional.of(member));
+
+            given(storeNativeQueryRepository.isAlreadyExistInBoundary(
+                    newImageRequest.getLat(),
+                    newImageRequest.getLng(),
+                    StreetAddress.of(newImageRequest.getStreetAddress()).getLargeAddress(),
+                    StreetAddress.of(newImageRequest.getStreetAddress()).getMediumAddress(),
+                    TEST_BOUNDARY)
+            ).willReturn(Optional.empty());
+
+            // when
+            storeService.updateStore(member.getId(), store.getId(), newImageRequest);
+
+            // then
+            then(imageService).should(times(1)).deleteSingleImage(anyString());
+        }
+
+        @Test
+        @DisplayName("이미지가 변경되지 않았을 경우 기존 이미지 삭제하지 않음")
+        void notDeleteOriginalImageWhenImageIsNotChanged() {
+            // given
+            given(storeRepository.findStoreWithMemberAndCategories(anyLong()))
+                    .willReturn(Optional.of(store));
+
+            given(memberRepository.findById(anyLong()))
+                    .willReturn(Optional.of(member));
+
+            given(storeNativeQueryRepository.isAlreadyExistInBoundary(
+                    sameImageRequest.getLat(),
+                    sameImageRequest.getLng(),
+                    StreetAddress.of(sameImageRequest.getStreetAddress()).getLargeAddress(),
+                    StreetAddress.of(sameImageRequest.getStreetAddress()).getMediumAddress(),
+                    TEST_BOUNDARY)
+            ).willReturn(Optional.empty());
+
+            // when
+            storeService.updateStore(member.getId(), store.getId(), sameImageRequest);
+
+            // then
+            then(imageService).should(never()).deleteSingleImage(anyString());
+        }
+
+        @Test
+        @DisplayName("카테고리가 변경되었을 경우")
+        void deleteOriginalCategoriesWhenCategoriesIsChanged() {
+            // given
+            given(storeRepository.findStoreWithMemberAndCategories(anyLong()))
+                    .willReturn(Optional.of(store));
+
+            given(memberRepository.findById(anyLong()))
+                    .willReturn(Optional.of(member));
+
+            given(storeNativeQueryRepository.isAlreadyExistInBoundary(
+                    newCategoryRequest.getLat(),
+                    newCategoryRequest.getLng(),
+                    StreetAddress.of(newCategoryRequest.getStreetAddress()).getLargeAddress(),
+                    StreetAddress.of(newCategoryRequest.getStreetAddress()).getMediumAddress(),
+                    TEST_BOUNDARY)
+            ).willReturn(Optional.empty());
+
+            // when
+            storeService.updateStore(store.getId(), member.getId(), newCategoryRequest);
+
+            // then
+            assertSoftly(
+                softly -> {
+                    softly.assertThat(store.getFoodCategories()).hasSize(2);
+                    softly.assertThat(store.getFoodCategories())
+                            .extracting("foodType")
+                            .usingRecursiveComparison()
+                            .ignoringCollectionOrder()
+                            .isEqualTo(List.of(FoodType.of("오뎅"), FoodType.of("타코야끼")));
+                }
+            );
+        }
     }
 
 }


### PR DESCRIPTION
## 🔥 연관 이슈
- close: #347 

## 📝 작업 요약
가게 정보 업데이트시 가게 카테고리 및 이미지 변경 단위 테스트

## 🔎 작업 상세 설명
1. 가게 정보 업데이트 서비스 로직 Store 클래스안으로 모듈화
2. 가게 카테고리 변경 시 카테고리 정상 변경 테스트
3. 가게 이미지에 변경 사항이 있다면 이미지 변경 로직 실행 테스트

## 🌟 리뷰 요구 사항

