### PR TITLE
refactor/#356 FoodCategory 엔티티의 FoodType 데이터타입을 enum에서 String으로 변경

### DIFF
--- a/src/main/java/com/pd/gilgeorigoreuda/member/dto/response/PreferredStoreInfoResponse.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/member/dto/response/PreferredStoreInfoResponse.java
@@ -54,7 +54,6 @@ public class PreferredStoreInfoResponse {
                 store.getFoodCategories()
                         .stream()
                         .map(FoodCategory::getFoodType)
-                        .map(FoodType::getFoodName)
                         .toList()
         );
     }

--- a/src/main/java/com/pd/gilgeorigoreuda/search/dto/response/FoodCategoryResponse.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/search/dto/response/FoodCategoryResponse.java
@@ -10,9 +10,9 @@ import lombok.NoArgsConstructor;
 public class FoodCategoryResponse {
 
     private Long id;
-    private FoodType foodType;
+    private String foodType;
 
-    private FoodCategoryResponse(final Long id, final FoodType foodType) {
+    private FoodCategoryResponse(final Long id, final String foodType) {
         this.id = id;
         this.foodType = foodType;
     }

--- a/src/main/java/com/pd/gilgeorigoreuda/search/repository/SearchRepository.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/search/repository/SearchRepository.java
@@ -1,6 +1,5 @@
 package com.pd.gilgeorigoreuda.search.repository;
 
-import com.pd.gilgeorigoreuda.store.domain.entity.FoodType;
 import com.pd.gilgeorigoreuda.store.domain.entity.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -18,7 +17,7 @@ public interface SearchRepository extends JpaRepository<Store, Long> {
         List<Store> findStoresByLatLngAndFoodTypes(
                 @Param("lat") final BigDecimal lat,
                 @Param("lng") final BigDecimal lng,
-                @Param("foodType") final FoodType foodType,
+                @Param("foodType") final String foodType,
                 @Param("distance") final Double distance
         );
 

--- a/src/main/java/com/pd/gilgeorigoreuda/search/resolver/SearchParameter.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/search/resolver/SearchParameter.java
@@ -18,7 +18,7 @@ public class SearchParameter {
     private BigDecimal mLng;
     private BigDecimal rLat;
     private BigDecimal rLng;
-    private FoodType foodType;
+    private String foodType;
 
     public static SearchParameter of(
             final String mLat,
@@ -44,8 +44,8 @@ public class SearchParameter {
         }
     }
 
-    private static FoodType initFoodType(final String foodType) {
-        return Objects.equals(foodType, "") ? null : FoodType.of(foodType);
+    private static String initFoodType(final String foodType) {
+        return Objects.equals(foodType, "") ? null : FoodType.of(foodType).getFoodName();
     }
 
 }

--- a/src/main/java/com/pd/gilgeorigoreuda/search/service/SearchService.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/search/service/SearchService.java
@@ -4,7 +4,6 @@ import com.pd.gilgeorigoreuda.common.util.DistanceCalculator;
 import com.pd.gilgeorigoreuda.search.dto.response.SearchStoreListResponse;
 import com.pd.gilgeorigoreuda.search.dto.response.SearchStoreResponse;
 import com.pd.gilgeorigoreuda.search.repository.SearchRepository;
-import com.pd.gilgeorigoreuda.store.domain.entity.FoodType;
 import com.pd.gilgeorigoreuda.store.domain.entity.Store;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,7 +26,7 @@ public class SearchService {
             final BigDecimal memberLng,
             final BigDecimal referenceLat,
             final BigDecimal referenceLng,
-            final FoodType foodType
+            final String foodType
     ) {
         List<SearchStoreResponse> searchStoreResponse = searchRepository
                 .findStoresByLatLngAndFoodTypes(referenceLat, referenceLng, foodType, DISTANCE_1KM)

--- a/src/main/java/com/pd/gilgeorigoreuda/store/domain/entity/FoodCategory.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/store/domain/entity/FoodCategory.java
@@ -2,8 +2,6 @@ package com.pd.gilgeorigoreuda.store.domain.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
@@ -30,9 +28,8 @@ public class FoodCategory {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(name = "food_type", nullable = false)
-	@Enumerated(EnumType.STRING)
-	private FoodType foodType;
+	@Column(name = "food_type", nullable = false, length = 50)
+	private String foodType;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "store_id", foreignKey = @ForeignKey(name = "fk_food_categories_store_id"))

--- a/src/main/java/com/pd/gilgeorigoreuda/store/dto/request/FoodCategoryRequest.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/store/dto/request/FoodCategoryRequest.java
@@ -23,7 +23,7 @@ public class FoodCategoryRequest {
 	public List<FoodCategory> toEntities() {
 		return foodCategories.stream()
 			.map(foodCategory -> FoodCategory.builder()
-				.foodType(FoodType.of(foodCategory))
+				.foodType(FoodType.of(foodCategory).getFoodName())
 				.build())
 			.toList();
 	}

--- a/src/main/java/com/pd/gilgeorigoreuda/store/dto/response/StoreResponse.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/store/dto/response/StoreResponse.java
@@ -108,7 +108,6 @@ public class StoreResponse {
 				store.getFoodCategories()
 						.stream()
 						.map(FoodCategory::getFoodType)
-						.map(FoodType::getFoodName)
 						.toList(),
 				store.getLastModifiedMemberNickname(),
 				StoreOwnerResponse.of(store.getMember())

--- a/src/main/java/com/pd/gilgeorigoreuda/store/dto/response/StoreUpdateResponse.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/store/dto/response/StoreUpdateResponse.java
@@ -69,7 +69,7 @@ public class StoreUpdateResponse {
 		this.foodCategories = foodCategories;
 	}
 
-	public static StoreUpdateResponse of(Store store) {
+	public static StoreUpdateResponse of(final Store store) {
 		return new StoreUpdateResponse(
 			store.getId(),
 			store.getName(),
@@ -90,7 +90,6 @@ public class StoreUpdateResponse {
 			store.getFoodCategories()
 				.stream()
 				.map(FoodCategory::getFoodType)
-				.map(FoodType::getFoodName)
 				.toList()
 		);
 	}

--- a/src/main/java/com/pd/gilgeorigoreuda/store/repository/StoreRepository.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/store/repository/StoreRepository.java
@@ -47,8 +47,7 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
 			"from reviews where store_id = s.id " +
 			"group by store_id) " +
 			"where id " +
-			"in(select store_id from reviews " +
-			"where store_id = s.id group by store_id)",
+			"in(select store_id from reviews where store_id = s.id group by store_id)",
 			nativeQuery = true)
 	void updateAllStoresAvgRating();
 
@@ -59,8 +58,7 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
 			"from store_visit_records where store_id = s.id " +
 			"group by store_id) " +
 			"where id " +
-			"in(select store_id from store_visit_records " +
-			"where store_id = s.id group by store_id)",
+			"in(select store_id from store_visit_records where store_id = s.id group by store_id)",
 			nativeQuery = true)
 	void updateAllStoresVisitCount();
 
@@ -71,15 +69,15 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
 			"from store_report_histories where store_id = s.id " +
 			"group by store_id) " +
 			"where id " +
-			"in(select store_id from store_report_histories " +
-			"where store_id = s.id group by store_id)",
+			"in(select store_id from store_report_histories where store_id = s.id group by store_id)",
 			nativeQuery = true)
 	void updateAllStoresReportCount();
 
 	@Modifying(clearAutomatically = true)
 	@Query(value = "update stores s " +
 			"set is_blocked = true " +
-			"where total_report_count >:count", nativeQuery = true)
+			"where total_report_count >:count",
+			nativeQuery = true)
 	void updateBlockedStore(@Param("count") int count);
 
 }

--- a/src/main/resources/db/migration/V3__alterfoodtypecolumn.sql
+++ b/src/main/resources/db/migration/V3__alterfoodtypecolumn.sql
@@ -1,0 +1,2 @@
+ALTER TABLE food_categories
+    MODIFY COLUMN food_type varchar(50) NOT NULL;

--- a/src/test/java/com/pd/gilgeorigoreuda/search/repository/SearchRepositoryTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/search/repository/SearchRepositoryTest.java
@@ -1,150 +1,161 @@
-//package com.pd.gilgeorigoreuda.search.repository;
-//
-//import com.pd.gilgeorigoreuda.member.domain.entity.Member;
-//import com.pd.gilgeorigoreuda.member.repository.MemberRepository;
-//import com.pd.gilgeorigoreuda.settings.RepositoryTest;
-//import com.pd.gilgeorigoreuda.store.domain.entity.*;
-//import com.pd.gilgeorigoreuda.store.repository.StoreRepository;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//
-//import java.math.BigDecimal;
-//import java.time.LocalTime;
-//import java.util.Arrays;
-//import java.util.List;
-//
-//import static org.assertj.core.api.Assertions.*;
-//
-//class SearchRepositoryTest extends RepositoryTest {
-//
-//    @Autowired
-//    private StoreRepository storeRepository;
-//
-//    @Autowired
-//    private SearchRepository searchRepository;
-//
-//    @Autowired
-//    private MemberRepository memberRepository;
-//
-//    private static final BigDecimal REFERENCE_LAT = new BigDecimal("37.53977925497371");
-//    private static final BigDecimal REFERENCE_LNG = new BigDecimal("127.0711654823082");
-//    private static final Double DISTANCE_1KM = 0.00012754530697130809;
-//
-//    @BeforeEach
-//    void setUp() {
-//        Member member = Member.builder()
-//                .id(1L)
-//                .nickname("nickname")
-//                .socialId("socialId")
-//                .build();
-//
-//        Store storeInDistance1 = Store.builder()
-//                .id(1L)
-//                .name("testStore1")
-//                .storeType(StoreType.FOOD_STALL)
-//                .detailLocation("testDetailLocation1")
-//                .averageRating(4.5)
-//                .businessDate("monday,friday")
-//                .openTime(LocalTime.of(10, 0))
-//                .closeTime(LocalTime.of(20, 0))
-//                .purchaseType(PurchaseType.CASH)
-//                .imageUrl("http://image.com")
-//                .lat(new BigDecimal("37.5399777941172"))
-//                .lng(new BigDecimal("127.07063386623555"))
-//                .streetAddress(StreetAddress.of("서울특별시 광진구 능동로22"))
-//                .totalVisitCount(100)
-//                .lastModifiedMemberNickname("nickname1")
-//                .member(member)
-//                .foodCategories(
-//                        Arrays.asList(
-//                                FoodCategory.builder().foodType(FoodType.ODENG).build(),
-//                                FoodCategory.builder().foodType(FoodType.BUNGEOPPANG).build()
-//                        )
-//                )
-//                .totalReportCount(0)
-//                .isBlocked(false)
-//                .build();
-//
-//        Store storeInDistance2 = Store.builder()
-//                .id(2L)
-//                .name("testStore2")
-//                .storeType(StoreType.FOOD_TRUCK)
-//                .detailLocation("testDetailLocation2")
-//                .averageRating(4.0)
-//                .businessDate("monday,sunday")
-//                .openTime(LocalTime.of(10, 0))
-//                .closeTime(LocalTime.of(20, 0))
-//                .purchaseType(PurchaseType.CASH)
-//                .imageUrl("http://image2.com")
-//                .lat(new BigDecimal("37.54035666149883"))
-//                .lng(new BigDecimal("127.06988177265133"))
-//                .streetAddress(StreetAddress.of("서울특별시 광진구 능동로123"))
-//                .totalVisitCount(100)
-//                .lastModifiedMemberNickname("nickname1")
-//                .member(member)
-//                .foodCategories(
-//                        Arrays.asList(
-//                                FoodCategory.builder().foodType(FoodType.ODENG).build(),
-//                                FoodCategory.builder().foodType(FoodType.EGGBREAD).build()
-//                        )
-//                )
-//                .totalReportCount(0)
-//                .isBlocked(false)
-//                .build();
-//
-//        Store storeOutOfDistance1 = Store.builder()
-//                .id(3L)
-//                .name("testStore3")
-//                .storeType(StoreType.FOOD_TRUCK)
-//                .detailLocation("testDetailLocation3")
-//                .averageRating(4.2)
-//                .businessDate("monday,sunday")
-//                .openTime(LocalTime.of(10, 0))
-//                .closeTime(LocalTime.of(20, 0))
-//                .purchaseType(PurchaseType.CASH)
-//                .imageUrl("http://image3.com")
-//                .lat(new BigDecimal("37.55734847509708"))
-//                .lng(new BigDecimal("127.02947109103378"))
-//                .streetAddress(StreetAddress.of("서울특별시 성동구 행당로77"))
-//                .totalVisitCount(100)
-//                .lastModifiedMemberNickname("nickname1")
-//                .member(member)
-//                .foodCategories(
-//                        Arrays.asList(
-//                                FoodCategory.builder().foodType(FoodType.FIRED).build(),
-//                                FoodCategory.builder().foodType(FoodType.HOTTEOK).build()
-//                        )
-//                )
-//                .totalReportCount(0)
-//                .isBlocked(false)
-//                .build();
-//
-//        memberRepository.save(member);
-//        storeRepository.save(storeInDistance1);
-//        storeRepository.save(storeInDistance2);
-//        storeRepository.save(storeOutOfDistance1);
-//    }
-//
-//    @Test
-//    @DisplayName("거리 1km 이내의 가게들을 찾는다.")
-//    public void findStoresByLatLngAndFoodTypes() {
-//        // given
-//        List<FoodType> foodTypes = Arrays.asList(FoodType.ODENG, FoodType.BUNGEOPPANG);
-//
-//        // when
-//        List<Store> result = searchRepository.findStoresByLatLngAndFoodTypes(REFERENCE_LAT, REFERENCE_LNG, foodTypes, DISTANCE_1KM);
-//
-//        // then
-//        assertThat(result).hasSize(2);
-//        assertThat(result.get(0).getName()).isEqualTo("testStore1");
-//        assertThat(result.get(0).getFoodCategories()).hasSize(2);
-//        assertThat(result.get(0).getFoodCategories().get(0).getFoodType()).isEqualTo(FoodType.ODENG);
-//        assertThat(result.get(0).getFoodCategories().get(1).getFoodType()).isEqualTo(FoodType.BUNGEOPPANG);
-//        assertThat(result.get(0).getStreetAddress().getLargeAddress()).isEqualTo("서울특별시");
-//        assertThat(result.get(0).getStreetAddress().getMediumAddress()).isEqualTo("광진구");
-//        assertThat(result.get(0).getStreetAddress().getSmallAddress()).isEqualTo("능동로22");
-//    }
-//
-//}
+package com.pd.gilgeorigoreuda.search.repository;
+
+import com.pd.gilgeorigoreuda.member.domain.entity.Member;
+import com.pd.gilgeorigoreuda.member.repository.MemberRepository;
+import com.pd.gilgeorigoreuda.settings.RepositoryTest;
+import com.pd.gilgeorigoreuda.store.domain.entity.*;
+import com.pd.gilgeorigoreuda.store.repository.StoreRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.math.BigDecimal;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+class SearchRepositoryTest extends RepositoryTest {
+
+    private static final BigDecimal REFERENCE_LAT = new BigDecimal("37.565366567584924");
+    private static final BigDecimal REFERENCE_LNG = new BigDecimal("126.97718688550951");
+    private static final Double DISTANCE_1KM = 0.00012754530697130809;
+    private static final Integer BOUNDARY_1KM = 1000;
+
+    @BeforeEach
+    void setUp() {
+        Member member = Member.builder()
+                .id(1L)
+                .nickname("nickname")
+                .socialId("socialId")
+                .build();
+
+        Store storeInBoundary1 = Store.builder()
+                .id(1L)
+                .name("시청역 2번 출구 오뎅 가게")
+                .storeType(StoreType.FOOD_STALL)
+                .detailLocation("testDetailLocation1")
+                .averageRating(4.5)
+                .businessDate("monday,friday")
+                .openTime(LocalTime.of(10, 0))
+                .closeTime(LocalTime.of(20, 0))
+                .purchaseType(PurchaseType.CASH)
+                .imageUrl("http://image.com")
+                .lat(new BigDecimal("37.565762957455874"))
+                .lng(new BigDecimal("126.97693774891424"))
+                .streetAddress(StreetAddress.of("서울특별시 중구 세종대로22"))
+                .totalVisitCount(100)
+                .lastModifiedMemberNickname("nickname1")
+                .member(member)
+                .foodCategories(
+                        Arrays.asList(
+                                FoodCategory.builder().foodType(FoodType.ODENG.getFoodName()).build(),
+                                FoodCategory.builder().foodType(FoodType.BUNGEOPPANG.getFoodName()).build()
+                        )
+                )
+                .totalReportCount(0)
+                .isBlocked(false)
+                .build();
+
+        Store storeInBoundary2 = Store.builder()
+                .id(2L)
+                .name("시청역 3번 출구 오뎅 가게")
+                .storeType(StoreType.FOOD_TRUCK)
+                .detailLocation("testDetailLocation2")
+                .averageRating(4.0)
+                .businessDate("monday,sunday")
+                .openTime(LocalTime.of(10, 0))
+                .closeTime(LocalTime.of(20, 0))
+                .purchaseType(PurchaseType.CASH)
+                .imageUrl("http://image2.com")
+                .lat(new BigDecimal("37.56611434367142"))
+                .lng(new BigDecimal("126.97692632163597"))
+                .streetAddress(StreetAddress.of("서울특별시 중구 세종대로123"))
+                .totalVisitCount(100)
+                .lastModifiedMemberNickname("nickname1")
+                .member(member)
+                .foodCategories(
+                        Arrays.asList(
+                                FoodCategory.builder().foodType(FoodType.ODENG.getFoodName()).build(),
+                                FoodCategory.builder().foodType(FoodType.EGGBREAD.getFoodName()).build()
+                        )
+                )
+                .totalReportCount(0)
+                .isBlocked(false)
+                .build();
+
+        Store storeInBoundary3 = Store.builder()
+                .id(3L)
+                .name("시청역 6번 출구 탕후루 가게")
+                .storeType(StoreType.FOOD_TRUCK)
+                .detailLocation("testDetailLocation2")
+                .averageRating(4.0)
+                .businessDate("monday,tuesday")
+                .openTime(LocalTime.of(10, 0))
+                .closeTime(LocalTime.of(20, 0))
+                .purchaseType(PurchaseType.CASH)
+                .imageUrl("http://image2.com")
+                .lat(new BigDecimal("37.56479901162554"))
+                .lng(new BigDecimal("126.97756057734291"))
+                .streetAddress(StreetAddress.of("서울특별시 중구 세종대로353"))
+                .totalVisitCount(100)
+                .lastModifiedMemberNickname("nickname1")
+                .member(member)
+                .foodCategories(
+                        Arrays.asList(
+                                FoodCategory.builder().foodType(FoodType.TANGHURU.getFoodName()).build()
+                        )
+                )
+                .totalReportCount(0)
+                .isBlocked(false)
+                .build();
+
+        Store storeOutOfBoundary1 = Store.builder()
+                .id(4L)
+                .name("경복궁역 4번 출구 분식")
+                .storeType(StoreType.FOOD_TRUCK)
+                .detailLocation("testDetailLocation3")
+                .averageRating(4.2)
+                .businessDate("monday,friday,sunday")
+                .openTime(LocalTime.of(10, 0))
+                .closeTime(LocalTime.of(20, 0))
+                .purchaseType(PurchaseType.CASH)
+                .imageUrl("http://image3.com")
+                .lat(new BigDecimal("37.57603352407639"))
+                .lng(new BigDecimal("126.9732441149734"))
+                .streetAddress(StreetAddress.of("서울특별시 중구 세종대로77"))
+                .totalVisitCount(100)
+                .lastModifiedMemberNickname("nickname1")
+                .member(member)
+                .foodCategories(
+                        Arrays.asList(
+                                FoodCategory.builder().foodType(FoodType.FIRED.getFoodName()).build(),
+                                FoodCategory.builder().foodType(FoodType.HOTTEOK.getFoodName()).build()
+                        )
+                )
+                .totalReportCount(0)
+                .isBlocked(false)
+                .build();
+
+        memberRepository.save(member);
+        storeRepository.save(storeInBoundary1);
+        storeRepository.save(storeInBoundary2);
+        storeRepository.save(storeInBoundary3);
+        storeRepository.save(storeOutOfBoundary1);
+    }
+
+    @Test
+    @DisplayName("거리 1km 이내의 오뎅 가게들을 찾는다.")
+    public void findStoresByLatLngAndFoodType() {
+        // given
+
+        // when
+
+        // then
+
+    }
+
+}

--- a/src/test/java/com/pd/gilgeorigoreuda/settings/RepositoryTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/settings/RepositoryTest.java
@@ -2,6 +2,11 @@ package com.pd.gilgeorigoreuda.settings;
 
 import static org.springframework.test.annotation.DirtiesContext.*;
 
+import com.pd.gilgeorigoreuda.member.repository.MemberRepository;
+import com.pd.gilgeorigoreuda.search.repository.SearchRepository;
+import com.pd.gilgeorigoreuda.store.repository.StoreNativeQueryRepository;
+import com.pd.gilgeorigoreuda.store.repository.StoreRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
@@ -16,5 +21,17 @@ import com.pd.gilgeorigoreuda.common.config.JpaConfig;
 @Import(JpaConfig.class)
 @ActiveProfiles("test")
 public abstract class RepositoryTest {
+
+    @Autowired
+    protected StoreRepository storeRepository;
+
+    @Autowired
+    protected SearchRepository searchRepository;
+
+    @Autowired
+    protected MemberRepository memberRepository;
+
+    @Autowired
+    protected StoreNativeQueryRepository storeNativeQueryRepository;
 
 }

--- a/src/test/java/com/pd/gilgeorigoreuda/settings/ServiceTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/settings/ServiceTest.java
@@ -55,12 +55,12 @@ public abstract class ServiceTest {
 
     protected static final FoodCategory FOOD_CATEGORY1 = FoodCategory.builder()
             .id(1L)
-            .foodType(FoodType.of("붕어빵"))
+            .foodType(FoodType.of("붕어빵").getFoodName())
             .build();
 
     protected static final FoodCategory FOOD_CATEGORY2 = FoodCategory.builder()
             .id(1L)
-            .foodType(FoodType.of("호떡"))
+            .foodType(FoodType.of("호떡").getFoodName())
             .build();
 
     protected static final Store STORE = Store.builder()

--- a/src/test/java/com/pd/gilgeorigoreuda/store/service/StoreServiceTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/store/service/StoreServiceTest.java
@@ -368,7 +368,7 @@ class StoreServiceTest extends ServiceTest {
                             .extracting("foodType")
                             .usingRecursiveComparison()
                             .ignoringCollectionOrder()
-                            .isEqualTo(List.of(FoodType.of("오뎅"), FoodType.of("타코야끼")));
+                            .isEqualTo(List.of("오뎅", "타코야끼"));
                 }
             );
         }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -18,6 +18,9 @@ spring:
     jdbc:
       initialize-schema: embedded
 
+  flyway:
+    enabled: false
+
 cloud:
   aws:
     credentials:


### PR DESCRIPTION
## 🔥 연관 이슈
- close: #356 

## 📝 작업 요약
FoodCategory 엔티티의 FoodType 데이터타입을 enum에서 String으로 변경

## 🔎 작업 상세 설명
데이터 칼럼 변경으로 인한 사이드 임팩트 수정

## 🌟 리뷰 요구 사항
