### PR TITLE
test/#383 login service test

### DIFF
--- a/src/main/java/com/pd/gilgeorigoreuda/login/service/LoginService.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/login/service/LoginService.java
@@ -13,11 +13,9 @@ import com.pd.gilgeorigoreuda.member.repository.MemberActiveInfoRepository;
 import com.pd.gilgeorigoreuda.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -34,17 +32,13 @@ public class LoginService {
         OauthProvider provider = oauthProviders.mapping(providerName);
         OauthUserInfo userInfo = provider.getUserInfo(code);
 
-        log.info("socialId : {}", userInfo.getSocialId());
-        log.info("nickname : {}", userInfo.getNickname());
-        log.info("profileImageUrl : {}", userInfo.getProfileImageUrl());
-
         Member member = findMemberOrElseCreateMember(
                 userInfo.getSocialId(),
                 userInfo.getNickname(),
                 userInfo.getProfileImageUrl()
         );
 
-        findMemberActiveInfoOrElseCreateMemberActiveInfo(member);
+        createMemberActiveInfoIfNull(member);
 
         MemberAccessRefreshToken memberAccessRefreshToken = jwtProvider.generateLoginToken(member.getId().toString());
 
@@ -84,7 +78,7 @@ public class LoginService {
         );
     }
 
-    private void findMemberActiveInfoOrElseCreateMemberActiveInfo(final Member member) {
+    private void createMemberActiveInfoIfNull(final Member member) {
         memberActiveInfoRepository.findByMemberId(member.getId())
                 .orElseGet(() -> createMemberActiveInfo(member));
     }

--- a/src/test/java/com/pd/gilgeorigoreuda/login/service/LoginServiceTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/login/service/LoginServiceTest.java
@@ -4,16 +4,15 @@ import com.pd.gilgeorigoreuda.login.domain.MemberAccessRefreshToken;
 import com.pd.gilgeorigoreuda.login.domain.MemberToken;
 import com.pd.gilgeorigoreuda.login.domain.OauthProvider;
 import com.pd.gilgeorigoreuda.login.domain.OauthUserInfo;
-import com.pd.gilgeorigoreuda.login.provider.KakaoOauthProvider;
+import com.pd.gilgeorigoreuda.login.exception.InvalidAccessTokenException;
+import com.pd.gilgeorigoreuda.login.exception.RenewalAccessTokenFailException;
 import com.pd.gilgeorigoreuda.member.domain.entity.Member;
 import com.pd.gilgeorigoreuda.member.domain.entity.MemberActiveInfo;
 import com.pd.gilgeorigoreuda.settings.ServiceTest;
-import com.pd.gilgeorigoreuda.settings.fixtures.MemberActiveInfoFixtures;
-import com.pd.gilgeorigoreuda.settings.fixtures.MemberFixtures;
-import com.pd.gilgeorigoreuda.settings.fixtures.MemberTokenFixtures;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 
 import java.util.Optional;
 
@@ -22,7 +21,6 @@ import static com.pd.gilgeorigoreuda.settings.fixtures.MemberFixtures.*;
 import static com.pd.gilgeorigoreuda.settings.fixtures.MemberTokenFixtures.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.assertj.core.api.SoftAssertions.*;
 import static org.mockito.BDDMockito.*;
 
 
@@ -40,10 +38,13 @@ class LoginServiceTest extends ServiceTest {
         given(someOauthUserInfo.getSocialId()).willReturn("some socialId");
         given(someOauthUserInfo.getNickname()).willReturn("some nickname");
         given(someOauthUserInfo.getProfileImageUrl()).willReturn("some profileImageUrl");
+
         given(memberRepository.findBySocialId(anyString())).willReturn(Optional.empty());
         given(memberRepository.save(any(Member.class))).willReturn(KIM());
+
         given(memberActiveInfoRepository.findByMemberId(anyLong())).willReturn(Optional.empty());
         given(memberActiveInfoRepository.save(any(MemberActiveInfo.class))).willReturn(KIM_ACTIVE_INFO());
+
         given(jwtProvider.generateLoginToken(anyString())).willReturn(mock(MemberAccessRefreshToken.class));
 
         // when
@@ -67,8 +68,10 @@ class LoginServiceTest extends ServiceTest {
         given(oauthProviders.mapping(anyString())).willReturn(someOauthProvider);
         given(someOauthProvider.getUserInfo(anyString())).willReturn(someOauthUserInfo);
         given(someOauthUserInfo.getSocialId()).willReturn("some socialId");
+
         given(memberRepository.findBySocialId(anyString())).willReturn(Optional.of(KIM()));
         given(memberActiveInfoRepository.findByMemberId(anyLong())).willReturn(Optional.of(KIM_ACTIVE_INFO()));
+
         given(jwtProvider.generateLoginToken(anyString())).willReturn(mock(MemberAccessRefreshToken.class));
 
         // when
@@ -83,6 +86,99 @@ class LoginServiceTest extends ServiceTest {
                 () -> then(memberTokenRepository).should(times(1)).save(any(MemberToken.class)),
                 () -> assertThat(memberAccessRefreshToken).isNotNull()
         );
+    }
+
+    @Nested
+    @DisplayName("AccessToken 재발급")
+    class regenerateAccessToken {
+
+        private static final String AUTHORIZATION_HEADER = HttpHeaders.AUTHORIZATION;
+        private static final String VALID_ACCESS_TOKEN = "ValidAccessToken";
+        private static final String INVALID_ACCESS_TOKEN = "InvalidAccessToken";
+        private static final String NEW_ACCESS_TOKEN = "NewAccessToken";
+
+        @Test
+        @DisplayName("AccessToken 재발급 - RefreshToken 이 유효하지만 AccessToken 기간 만료인 경우")
+        void whenRefreshTokenIsValidThenRegenerateAccessToken() {
+            // given
+            given(bearerExtractor.extractAccessToken(AUTHORIZATION_HEADER)).willReturn(VALID_ACCESS_TOKEN);
+            given(memberTokenRepository.findByAccessToken(anyString())).willReturn(Optional.of(KIM_TOKEN()));
+            given(jwtProvider.isValidRefreshButInvalidAccessToken(KIM_TOKEN().getRefreshToken(), KIM_TOKEN().getAccessToken())).willReturn(true);
+            given(jwtProvider.regenerateAccessToken(KIM_TOKEN().getMemberId().toString())).willReturn(NEW_ACCESS_TOKEN);
+
+            // when
+            String accessToken = loginService.regenerateAccessToken(AUTHORIZATION_HEADER);
+
+            // then
+            assertAll(
+                    () -> then(bearerExtractor).should(times(1)).extractAccessToken(AUTHORIZATION_HEADER),
+                    () -> then(memberTokenRepository).should(times(1)).findByAccessToken(anyString()),
+                    () -> then(jwtProvider).should(times(1)).isValidRefreshButInvalidAccessToken(anyString(), anyString()),
+                    () -> then(jwtProvider).should(times(1)).regenerateAccessToken(anyString()),
+                    () -> then(memberTokenRepository).should(times(1)).updateAccessToken(KIM_TOKEN().getMemberId(), NEW_ACCESS_TOKEN),
+                    () -> assertThat(accessToken).isNotNull()
+            );
+        }
+
+        @Test
+        @DisplayName("AccessToken 재발급 - RefreshToken, AccessToken 모두 유효한 경우")
+        void whenRefreshTokenAndAccessTokenAreValidThenReturnAccessToken() {
+            // given
+            given(bearerExtractor.extractAccessToken(AUTHORIZATION_HEADER)).willReturn(VALID_ACCESS_TOKEN);
+            given(memberTokenRepository.findByAccessToken(anyString())).willReturn(Optional.of(KIM_TOKEN()));
+            given(jwtProvider.isValidRefreshAndValidAccessToken(KIM_TOKEN().getRefreshToken(), KIM_TOKEN().getAccessToken())).willReturn(true);
+
+            // when
+            String accessToken = loginService.regenerateAccessToken(AUTHORIZATION_HEADER);
+
+            // then
+            assertAll(
+                    () -> then(bearerExtractor).should(times(1)).extractAccessToken(AUTHORIZATION_HEADER),
+                    () -> then(memberTokenRepository).should(times(1)).findByAccessToken(anyString()),
+                    () -> then(jwtProvider).should(times(1)).isValidRefreshAndValidAccessToken(anyString(), anyString()),
+                    () -> then(memberTokenRepository).should(never()).updateAccessToken(anyLong(), anyString()),
+                    () -> assertThat(accessToken).isNotNull()
+            );
+        }
+
+        @Test
+        @DisplayName("AccessToken 재발급 - RefreshToken이 유효하지 않은 경우 AccessToken 갱신 실패")
+        void whenRefreshTokenIsInvalidThenThrowException() {
+            // given
+            given(bearerExtractor.extractAccessToken(AUTHORIZATION_HEADER)).willReturn(INVALID_ACCESS_TOKEN);
+            given(memberTokenRepository.findByAccessToken(anyString())).willReturn(Optional.of(KIM_TOKEN()));
+            given(jwtProvider.isValidRefreshButInvalidAccessToken(KIM_TOKEN().getRefreshToken(), KIM_TOKEN().getAccessToken())).willReturn(false);
+            given(jwtProvider.isValidRefreshAndValidAccessToken(KIM_TOKEN().getRefreshToken(), KIM_TOKEN().getAccessToken())).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> loginService.regenerateAccessToken(AUTHORIZATION_HEADER))
+                    .isInstanceOf(RenewalAccessTokenFailException.class);
+        }
+
+        @Test
+        @DisplayName("AccessToken 재발급 - 저장된 AccessToken이 없는 경우 잘못된 AccessToken 예외 발생")
+        void whenAccessTokenIsNotFoundThenThrowException() {
+            // given
+            given(bearerExtractor.extractAccessToken(AUTHORIZATION_HEADER)).willReturn(INVALID_ACCESS_TOKEN);
+            given(memberTokenRepository.findByAccessToken(anyString())).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> loginService.regenerateAccessToken(AUTHORIZATION_HEADER))
+                    .isInstanceOf(InvalidAccessTokenException.class);
+        }
+    }
+
+    @Test
+    @DisplayName("로그아웃 - AccessToken 삭제")
+    void deleteMemberToken() {
+        // given
+        given(bearerExtractor.extractAccessToken(anyString())).willReturn(KIM_TOKEN().getAccessToken());
+
+        // when
+        loginService.deleteMemberToken(anyString());
+
+        // then
+        then(memberTokenRepository).should(times(1)).deleteByAccessToken(KIM_TOKEN().getAccessToken());
     }
 
 }

--- a/src/test/java/com/pd/gilgeorigoreuda/login/service/LoginServiceTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/login/service/LoginServiceTest.java
@@ -1,11 +1,88 @@
 package com.pd.gilgeorigoreuda.login.service;
 
+import com.pd.gilgeorigoreuda.login.domain.MemberAccessRefreshToken;
+import com.pd.gilgeorigoreuda.login.domain.MemberToken;
+import com.pd.gilgeorigoreuda.login.domain.OauthProvider;
+import com.pd.gilgeorigoreuda.login.domain.OauthUserInfo;
+import com.pd.gilgeorigoreuda.login.provider.KakaoOauthProvider;
+import com.pd.gilgeorigoreuda.member.domain.entity.Member;
+import com.pd.gilgeorigoreuda.member.domain.entity.MemberActiveInfo;
 import com.pd.gilgeorigoreuda.settings.ServiceTest;
+import com.pd.gilgeorigoreuda.settings.fixtures.MemberActiveInfoFixtures;
+import com.pd.gilgeorigoreuda.settings.fixtures.MemberFixtures;
+import com.pd.gilgeorigoreuda.settings.fixtures.MemberTokenFixtures;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
+import static com.pd.gilgeorigoreuda.settings.fixtures.MemberActiveInfoFixtures.*;
+import static com.pd.gilgeorigoreuda.settings.fixtures.MemberFixtures.*;
+import static com.pd.gilgeorigoreuda.settings.fixtures.MemberTokenFixtures.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.SoftAssertions.*;
+import static org.mockito.BDDMockito.*;
+
 
 class LoginServiceTest extends ServiceTest {
+
+    private final OauthProvider someOauthProvider = mock(OauthProvider.class);
+    private final OauthUserInfo someOauthUserInfo = mock(OauthUserInfo.class);
+
+    @Test
+    @DisplayName("제공자 이름과 코드를 받아서 로그인을 수행 - 회원정보가 없는 경우 회원가입 후 로그인")
+    void whenSocialIdIsNullThenCreateMemberAndLogin() {
+        // given
+        given(oauthProviders.mapping(anyString())).willReturn(someOauthProvider);
+        given(someOauthProvider.getUserInfo(anyString())).willReturn(someOauthUserInfo);
+        given(someOauthUserInfo.getSocialId()).willReturn("some socialId");
+        given(someOauthUserInfo.getNickname()).willReturn("some nickname");
+        given(someOauthUserInfo.getProfileImageUrl()).willReturn("some profileImageUrl");
+        given(memberRepository.findBySocialId(anyString())).willReturn(Optional.empty());
+        given(memberRepository.save(any(Member.class))).willReturn(KIM());
+        given(memberActiveInfoRepository.findByMemberId(anyLong())).willReturn(Optional.empty());
+        given(memberActiveInfoRepository.save(any(MemberActiveInfo.class))).willReturn(KIM_ACTIVE_INFO());
+        given(jwtProvider.generateLoginToken(anyString())).willReturn(mock(MemberAccessRefreshToken.class));
+
+        // when
+        MemberAccessRefreshToken memberAccessRefreshToken = loginService.login("providerName", "code");
+
+        // then
+        assertAll(
+                () -> then(memberRepository).should(times(1)).findBySocialId(anyString()),
+                () -> then(memberRepository).should(times(1)).save(any(Member.class)),
+                () -> then(memberActiveInfoRepository).should(times(1)).findByMemberId(anyLong()),
+                () -> then(memberActiveInfoRepository).should(times(1)).save(any(MemberActiveInfo.class)),
+                () -> then(memberTokenRepository).should(times(1)).save(any(MemberToken.class)),
+                () -> assertThat(memberAccessRefreshToken).isNotNull()
+        );
+    }
+
+    @Test
+    @DisplayName("제공자 이름과 코드를 받아서 로그인을 수행 - 회원정보가 있는 경우 로그인")
+    void whenSocialIdIsNotNullThenLogin() {
+        // given
+        given(oauthProviders.mapping(anyString())).willReturn(someOauthProvider);
+        given(someOauthProvider.getUserInfo(anyString())).willReturn(someOauthUserInfo);
+        given(someOauthUserInfo.getSocialId()).willReturn("some socialId");
+        given(memberRepository.findBySocialId(anyString())).willReturn(Optional.of(KIM()));
+        given(memberActiveInfoRepository.findByMemberId(anyLong())).willReturn(Optional.of(KIM_ACTIVE_INFO()));
+        given(jwtProvider.generateLoginToken(anyString())).willReturn(mock(MemberAccessRefreshToken.class));
+
+        // when
+        MemberAccessRefreshToken memberAccessRefreshToken = loginService.login("providerName", "code");
+
+        // then
+        assertAll(
+                () -> then(memberRepository).should(times(1)).findBySocialId(anyString()),
+                () -> then(memberRepository).should(never()).save(any(Member.class)),
+                () -> then(memberActiveInfoRepository).should(times(1)).findByMemberId(anyLong()),
+                () -> then(memberActiveInfoRepository).should(never()).save(any(MemberActiveInfo.class)),
+                () -> then(memberTokenRepository).should(times(1)).save(any(MemberToken.class)),
+                () -> assertThat(memberAccessRefreshToken).isNotNull()
+        );
+    }
 
 }

--- a/src/test/java/com/pd/gilgeorigoreuda/settings/ServiceTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/settings/ServiceTest.java
@@ -75,6 +75,6 @@ public abstract class ServiceTest {
     protected JwtProvider jwtProvider;
 
     @Mock
-    protected BearerTokenExtractor bearerTokenExtractor;
+    protected BearerTokenExtractor bearerExtractor;
 
 }

--- a/src/test/java/com/pd/gilgeorigoreuda/settings/ServiceTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/settings/ServiceTest.java
@@ -3,15 +3,13 @@ package com.pd.gilgeorigoreuda.settings;
 import com.pd.gilgeorigoreuda.common.util.DistanceCalculator;
 import com.pd.gilgeorigoreuda.image.service.ImageService;
 import com.pd.gilgeorigoreuda.login.domain.OauthProvider;
+import com.pd.gilgeorigoreuda.login.domain.OauthProviders;
 import com.pd.gilgeorigoreuda.login.jwt.BearerTokenExtractor;
 import com.pd.gilgeorigoreuda.login.jwt.JwtProvider;
 import com.pd.gilgeorigoreuda.login.repository.MemberTokenRepository;
 import com.pd.gilgeorigoreuda.login.service.LoginService;
-import com.pd.gilgeorigoreuda.member.domain.entity.Member;
 import com.pd.gilgeorigoreuda.member.repository.MemberActiveInfoRepository;
 import com.pd.gilgeorigoreuda.member.repository.MemberRepository;
-import com.pd.gilgeorigoreuda.store.domain.entity.*;
-import com.pd.gilgeorigoreuda.store.dto.request.BusinessDateRequest;
 import com.pd.gilgeorigoreuda.store.repository.StoreNativeQueryRepository;
 import com.pd.gilgeorigoreuda.store.repository.StoreRepository;
 import com.pd.gilgeorigoreuda.store.service.StoreService;
@@ -23,11 +21,6 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.math.BigDecimal;
-import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @MockitoSettings
 @Transactional
@@ -71,6 +64,9 @@ public abstract class ServiceTest {
 
     @Mock
     protected MemberActiveInfoRepository memberActiveInfoRepository;
+
+    @Mock
+    protected OauthProviders oauthProviders;
 
     @Mock
     protected OauthProvider oauthProvider;

--- a/src/test/java/com/pd/gilgeorigoreuda/settings/fixtures/MemberTokenFixtures.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/settings/fixtures/MemberTokenFixtures.java
@@ -9,8 +9,8 @@ public class MemberTokenFixtures {
     public static  MemberToken KIM_TOKEN() {
         return MemberToken.builder()
                 .memberId(KIM().getId())
-                .accessToken("accessToken")
-                .refreshToken("refreshToken")
+                .accessToken("AccessToken")
+                .refreshToken("RefreshToken")
                 .build();
     }
 

--- a/src/test/java/com/pd/gilgeorigoreuda/settings/fixtures/MemberTokenFixtures.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/settings/fixtures/MemberTokenFixtures.java
@@ -1,0 +1,17 @@
+package com.pd.gilgeorigoreuda.settings.fixtures;
+
+import com.pd.gilgeorigoreuda.login.domain.MemberToken;
+
+import static com.pd.gilgeorigoreuda.settings.fixtures.MemberFixtures.*;
+
+public class MemberTokenFixtures {
+
+    public static  MemberToken KIM_TOKEN() {
+        return MemberToken.builder()
+                .memberId(KIM().getId())
+                .accessToken("accessToken")
+                .refreshToken("refreshToken")
+                .build();
+    }
+
+}


### PR DESCRIPTION
## 🔥 연관 이슈
- close: #383 

## 📝 작업 요약
로그인 서비스 로직 단위 테스트

## 🔎 작업 상세 설명
1. 제공자 이름과 코드를 받아서 로그인을 수행 - 회원정보가 없는 경우 회원가입 후 로그인
 - 특정 제공자의 이름과 코드를 받아서 로그인을 수행하는 경우 테스트
- 만약 해당 회원 정보가 없는 경우, 회원을 새로 생성한 후 로그인 수행

2. 제공자 이름과 코드를 받아서 로그인을 수행 - 회원정보가 있는 경우 로그인
- 이미 해당 제공자의 회원 정보가 있는 경우, 새로 회원을 생성하지 않고 기존 회원으로 로그인

3. AccessToken 재발급
- AccessToken의 유효기간이 만료되었거나 RefreshToken이 유효하지만 AccessToken이 만료된 경우, 새로운 AccessToken을 발급 가능
- AccessToken과 RefreshToken이 모두 유효한 경우에는 새로운 AccessToken을 발급하지 않고 기존 AccessToken을 반환
- RefreshToken이 유효하지 않은 경우나 저장된 AccessToken이 없는 경우 갱신 실패

4. 로그아웃 - AccessToken 삭제
- 로그아웃 시 해당 AccessToken을 삭제

## 🌟 리뷰 요구 사항

