### PR TITLE
Test/#386 MemberTokenRepository 단위 테스트

### DIFF
--- a/src/main/java/com/pd/gilgeorigoreuda/login/repository/MemberTokenRepository.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/login/repository/MemberTokenRepository.java
@@ -14,7 +14,7 @@ public interface MemberTokenRepository extends JpaRepository<MemberToken, Long> 
     @Query("delete from MemberToken mt where mt.accessToken = :accessToken")
     void deleteByAccessToken(@Param("accessToken") final String accessToken);
 
-    @Modifying
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("update MemberToken mt set mt.accessToken = :accessToken where mt.memberId = :memberId")
     void updateAccessToken(@Param("memberId") final Long memberId, @Param("accessToken") final String accessToken);
 

--- a/src/test/java/com/pd/gilgeorigoreuda/login/repository/MemberTokenRepositoryTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/login/repository/MemberTokenRepositoryTest.java
@@ -5,6 +5,8 @@ import com.pd.gilgeorigoreuda.settings.RepositoryTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
 import static com.pd.gilgeorigoreuda.settings.fixtures.MemberTokenFixtures.*;
 import static org.assertj.core.api.Assertions.*;
 
@@ -37,6 +39,25 @@ class MemberTokenRepositoryTest extends RepositoryTest {
 
         // then
         assertThat(memberTokenRepository.findByAccessToken(accessToken)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("MemberId를 통해 AccessToken을 업데이트")
+    void updateAccessToken() {
+        // given
+        MemberToken KIM_TOKEN = dataBuilder.buildMemberToken(KIM_TOKEN());
+        MemberToken LEE_TOKEN = dataBuilder.buildMemberToken(LEE_TOKEN());
+        Long memberId = KIM_TOKEN.getMemberId();
+        String newAccessToken = "Kims New AccessToken";
+
+        // when
+        memberTokenRepository.updateAccessToken(memberId, newAccessToken);
+
+        // then
+        memberTokenRepository.findByAccessToken(newAccessToken)
+                .ifPresent(
+                        newMemberToken -> assertThat(newMemberToken.getAccessToken()).isEqualTo(newAccessToken)
+                );
     }
 
 }

--- a/src/test/java/com/pd/gilgeorigoreuda/login/repository/MemberTokenRepositoryTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/login/repository/MemberTokenRepositoryTest.java
@@ -1,0 +1,28 @@
+package com.pd.gilgeorigoreuda.login.repository;
+
+import com.pd.gilgeorigoreuda.login.domain.MemberToken;
+import com.pd.gilgeorigoreuda.settings.RepositoryTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.pd.gilgeorigoreuda.settings.fixtures.MemberTokenFixtures.*;
+import static org.assertj.core.api.Assertions.*;
+
+class MemberTokenRepositoryTest extends RepositoryTest {
+
+    @Test
+    @DisplayName("AccessToken을 통해 MemberToken 객체 조회")
+    void findByAccessToken() {
+        // given
+        MemberToken KIM_TOKEN = dataBuilder.buildMemberToken(KIM_TOKEN());
+        String accessToken = KIM_TOKEN.getAccessToken();
+
+        // when & then
+        memberTokenRepository.findByAccessToken(accessToken)
+                .ifPresent(
+                        memberToken -> assertThat(accessToken).isEqualTo(memberToken.getAccessToken())
+                );
+
+    }
+
+}

--- a/src/test/java/com/pd/gilgeorigoreuda/login/repository/MemberTokenRepositoryTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/login/repository/MemberTokenRepositoryTest.java
@@ -25,4 +25,18 @@ class MemberTokenRepositoryTest extends RepositoryTest {
 
     }
 
+    @Test
+    @DisplayName("AccessToken을 통해 MemberToken 객체 삭제")
+    void deleteByAccessToken() {
+        // given
+        MemberToken KIM_TOKEN = dataBuilder.buildMemberToken(KIM_TOKEN());
+        String accessToken = KIM_TOKEN.getAccessToken();
+
+        // when
+        memberTokenRepository.deleteByAccessToken(accessToken);
+
+        // then
+        assertThat(memberTokenRepository.findByAccessToken(accessToken)).isEmpty();
+    }
+
 }

--- a/src/test/java/com/pd/gilgeorigoreuda/settings/RepositoryTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/settings/RepositoryTest.java
@@ -2,6 +2,7 @@ package com.pd.gilgeorigoreuda.settings;
 
 import static org.springframework.test.annotation.DirtiesContext.*;
 
+import com.pd.gilgeorigoreuda.login.repository.MemberTokenRepository;
 import com.pd.gilgeorigoreuda.member.repository.MemberRepository;
 import com.pd.gilgeorigoreuda.search.repository.SearchRepository;
 import com.pd.gilgeorigoreuda.settings.builder.BuilderSupporter;
@@ -43,5 +44,8 @@ public abstract class RepositoryTest {
 
     @Autowired
     protected StoreVisitRecordRepository storeVisitRecordRepository;
+
+    @Autowired
+    protected MemberTokenRepository memberTokenRepository;
 
 }

--- a/src/test/java/com/pd/gilgeorigoreuda/settings/fixtures/MemberTokenFixtures.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/settings/fixtures/MemberTokenFixtures.java
@@ -9,8 +9,16 @@ public class MemberTokenFixtures {
     public static  MemberToken KIM_TOKEN() {
         return MemberToken.builder()
                 .memberId(KIM().getId())
-                .accessToken("AccessToken")
-                .refreshToken("RefreshToken")
+                .accessToken("Kim AccessToken")
+                .refreshToken("Lee RefreshToken")
+                .build();
+    }
+
+    public static  MemberToken LEE_TOKEN() {
+        return MemberToken.builder()
+                .memberId(LEE().getId())
+                .accessToken("Lee AccessToken")
+                .refreshToken("Lee RefreshToken")
                 .build();
     }
 


### PR DESCRIPTION
## 🔥 연관 이슈
- close: #386 

## 📝 작업 요약
해당 커밋은 MemberTokenRepository 클래스에 대한 단위 테스트를 추가하였습니다. 이 테스트는 findByAccessToken 메서드, deleteByAccessToken 메서드, updateAccessToken 메서드를 각각 테스트하고 있습니다.

## 🔎 작업 상세 설명
1. findByAccessToken 테스트:
   - 특정 AccessToken을 이용하여 MemberToken 객체를 조회하는 테스트
   - 주어진 AccessToken으로 MemberToken을 조회하고, 조회된 MemberToken이 존재하는지 확인

2. deleteByAccessToken 테스트:
   - 특정 AccessToken을 이용하여 MemberToken 객체를 삭제하는 테스트
   - 주어진 AccessToken으로 MemberToken을 삭제한 후, 해당 AccessToken으로 다시 조회하여 삭제되었는지 확인

3. updateAccessToken 테스트:
   - 특정 MemberId에 해당하는 MemberToken의 AccessToken을 업데이트하는 테스트
   - 주어진 MemberId에 해당하는 MemberToken의 AccessToken을 새로운 값으로 업데이트한 후, 업데이트된 AccessToken으로 조회 확인

## 🌟 리뷰 요구 사항

