### PR TITLE
test/#389 카카오 로그인 외부 API 연동 단위 테스트

### DIFF
--- a/src/main/java/com/pd/gilgeorigoreuda/login/domain/OauthAccessToken.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/login/domain/OauthAccessToken.java
@@ -2,11 +2,13 @@ package com.pd.gilgeorigoreuda.login.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class OauthAccessToken {
 
     @JsonProperty("access_token")

--- a/src/main/java/com/pd/gilgeorigoreuda/login/provider/KakaoOauthProvider.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/login/provider/KakaoOauthProvider.java
@@ -6,7 +6,6 @@ import com.pd.gilgeorigoreuda.login.domain.OauthUserInfo;
 import com.pd.gilgeorigoreuda.login.domain.oauthuserinfo.KakaoUserInfo;
 import com.pd.gilgeorigoreuda.login.exception.InvalidAuthorizationCodeException;
 import com.pd.gilgeorigoreuda.login.exception.NotSupportedOauthServiceException;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
@@ -15,7 +14,6 @@ import org.springframework.util.MultiValueMap;
 
 import java.util.Optional;
 
-@Slf4j
 @Component
 public class KakaoOauthProvider implements OauthProvider {
 
@@ -85,9 +83,6 @@ public class KakaoOauthProvider implements OauthProvider {
                 accessTokenRequestEntity,
                 OauthAccessToken.class
         );
-
-        log.info("accessTokenResponse.getAccessToken : {}", accessTokenResponse.getBody().getAccessToken());
-        log.info("accessTokenResponse.getRefreshToken : {}", accessTokenResponse.getBody().getRefreshToken());
 
         return Optional.ofNullable(accessTokenResponse.getBody())
                 .orElseThrow(InvalidAuthorizationCodeException::new)

--- a/src/test/java/com/pd/gilgeorigoreuda/login/provider/KakaoOauthProviderTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/login/provider/KakaoOauthProviderTest.java
@@ -1,0 +1,107 @@
+package com.pd.gilgeorigoreuda.login.provider;
+
+import com.pd.gilgeorigoreuda.login.domain.OauthAccessToken;
+import com.pd.gilgeorigoreuda.login.domain.OauthUserInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.springframework.http.*;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+@MockitoSettings
+class KakaoOauthProviderTest {
+
+    @InjectMocks
+    private KakaoOauthProvider kakaoOauthProvider;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    private static final String TEST_CODE = "test_code";
+    private static final String TEST_ACCESS_TOKEN = "test access token";
+    private static final String TEST_CLIENT_ID = "dd83fb5281e50c8508ffc20b8dc07799/test";
+    private static final String TEST_REDIRECT_URL = "http://localhost:3000/oauth2/callback/test/kakao";
+    private static final String TEST_TOKEN_URL = "https://kauth.kakao.com/oauth/test/token";
+    private static final String TEST_USER_INFO_URL = "https://kapi.kakao.com/v2/user/test/me";
+
+    private static final OauthAccessToken mockOauthAccessToken = mock(OauthAccessToken.class);
+
+    private HttpEntity<MultiValueMap<String, String>> setRequestAccessTokenHeaderAndBody(final String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("code", TEST_CODE);
+        body.add("client_id", TEST_CLIENT_ID);
+        body.add("redirect_uri", TEST_REDIRECT_URL);
+        body.add("grant_type", "authorization_code");
+
+        return new HttpEntity<>(body, headers);
+    }
+
+    private ResponseEntity<OauthUserInfo> getUserInfo() {
+        return restTemplate.exchange(
+                TEST_USER_INFO_URL,
+                HttpMethod.GET,
+                new HttpEntity<>(
+                        new HttpHeaders() {{
+                            setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+                            setBearerAuth(TEST_ACCESS_TOKEN);
+                        }}
+                ),
+                OauthUserInfo.class
+        );
+    }
+
+    private ResponseEntity<OauthAccessToken> getRequestAccessToken() {
+        return restTemplate.exchange(
+                TEST_TOKEN_URL,
+                HttpMethod.POST,
+                setRequestAccessTokenHeaderAndBody(TEST_CODE),
+                OauthAccessToken.class
+        );
+    }
+
+    @BeforeEach
+    void setUp() {
+        kakaoOauthProvider = new KakaoOauthProvider(TEST_CLIENT_ID, TEST_REDIRECT_URL, TEST_TOKEN_URL, TEST_USER_INFO_URL);
+    }
+
+    @Test
+    @DisplayName("카카오 로그인 서비스인지 확인한다.")
+    void isKakaoProvider() {
+        assertThat(kakaoOauthProvider.is("kakao")).isTrue();
+        assertThat(kakaoOauthProvider.is("naver")).isFalse();
+    }
+
+
+    @Test
+    @DisplayName("인가 코드로 AccessToken 요청 후 AccessToken을 헤더에 담아 카카오에 유저 정보를 요청한다.")
+    void getUserInfo_success() {
+//        // given
+//        ResponseEntity<OauthAccessToken> mockResponseEntity = mock(ResponseEntity.class);
+//        ResponseEntity<OauthUserInfo> mockUserInfoResponseEntity = mock(ResponseEntity.class);
+//
+//        given(getRequestAccessToken()).willReturn(mockResponseEntity);
+//
+//        given(mockResponseEntity.getBody()).willReturn(mockOauthAccessToken);
+//        given(mockOauthAccessToken.getAccessToken()).willReturn(TEST_ACCESS_TOKEN);
+//
+//        given(getUserInfo()).willReturn(mockUserInfoResponseEntity);
+//
+//        // when
+//        OauthUserInfo kakaoUserInfo = kakaoOauthProvider.getUserInfo(TEST_CODE);
+//
+//        // given
+//        assertThat(kakaoUserInfo).isNotNull();
+    }
+
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -40,10 +40,10 @@ cloud:
 oauth2:
   provider:
     kakao:
-      client-id: dd83fb5281e50c8508ffc20b8dc07799
-      redirect-url: http://localhost:3000/oauth2/callback/kakao
-      token-url: https://kauth.kakao.com/oauth/token
-      user-info-url: https://kapi.kakao.com/v2/user/me
+      client-id: dd83fb5281e50c8508ffc20b8dc07799/test
+      redirect-url: http://localhost:3000/oauth2/callback/test/kakao
+      token-url: https://kauth.kakao.com/oauth/test/token
+      user-info-url: https://kapi.kakao.com/v2/user/test/me
 
 security:
   jwt:


### PR DESCRIPTION
## 🔥 연관 이슈
- close: #389
- 
## 📝 작업 요약
KakaoOauthProvider 클래스의 단위 테스트 작성

## 🔎 작업 상세 설명
1. KakaoOauthProvider 클래스의 단위 테스트를 작성하였습니다. 해당 테스트는 카카오 로그인 서비스인지 확인
2. 인가 코드로 AccessToken을 요청한 후 AccessToken을 헤더에 담아 카카오에 유저 정보를 요청하는지를 확인



## 🌟 리뷰 요구 사항

