### PR TITLE
test/#391 search controller test

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -136,3 +136,14 @@ include::{snippets}/visit-controller-test/verify-visit-success/http-request.adoc
 include::{snippets}/visit-controller-test/verify-visit-success/request-headers.adoc[]
 include::{snippets}/visit-controller-test/verify-visit-success/path-parameters.adoc[]
 include::{snippets}/visit-controller-test/verify-visit-success/request-fields.adoc[]
+
+
+=== 가게 검색 (GET /search?mLat=&mLng=&rLat=&rLng=&foodType=)
+
+==== request
+include::{snippets}/search-controller-test/search-by-lat-lng-and-food-categories/http-request.adoc[]
+include::{snippets}/search-controller-test/search-by-lat-lng-and-food-categories/query-parameters.adoc[]
+
+==== response
+include::{snippets}/search-controller-test/search-by-lat-lng-and-food-categories/http-response.adoc[]
+include::{snippets}/search-controller-test/search-by-lat-lng-and-food-categories/response-fields.adoc[]

--- a/src/test/java/com/pd/gilgeorigoreuda/search/controller/SearchControllerTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/search/controller/SearchControllerTest.java
@@ -1,0 +1,126 @@
+package com.pd.gilgeorigoreuda.search.controller;
+
+import com.pd.gilgeorigoreuda.search.dto.response.SearchStoreListResponse;
+import com.pd.gilgeorigoreuda.search.dto.response.SearchStoreResponse;
+import com.pd.gilgeorigoreuda.search.service.SearchService;
+import com.pd.gilgeorigoreuda.settings.ControllerTest;
+import com.pd.gilgeorigoreuda.settings.fixtures.StoreFixtures;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.*;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.assertj.core.api.Assertions.*;
+
+@WebMvcTest(SearchController.class)
+@AutoConfigureRestDocs
+class SearchControllerTest extends ControllerTest {
+
+    @MockBean
+    private SearchService searchService;
+
+    private ResultActions performSearchRequest(final String mLat, final String mLng, final String rLat, final String rLng, final String foodType) throws Exception {
+        return mockMvc.perform(
+                get("/api/v1/search/address")
+                        .param("mLat", mLat)
+                        .param("mLng",mLng)
+                        .param("rLat", rLat)
+                        .param("rLng", rLng)
+                        .param("foodType", foodType)
+                        .contentType(APPLICATION_JSON)
+        );
+    }
+
+    private SearchStoreListResponse getSearchStoreListResponse() {
+        return SearchStoreListResponse.of(
+                List.of(
+                        SearchStoreResponse.of(
+                                StoreFixtures.TACOYAKI(),
+                                10
+                        ),
+                        SearchStoreResponse.of(
+                                StoreFixtures.TANGHURU(),
+                                20
+                        ),
+                        SearchStoreResponse.of(
+                                StoreFixtures.TTEOKBOKKI(),
+                                30
+                        )
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("주변 가게 검색 테스트")
+    void searchByLatLngAndFoodCategories() throws Exception {
+        // given
+        SearchStoreListResponse searchStoreListResponse = getSearchStoreListResponse();
+
+        given(searchService.searchByLatLngAndFoodCategories(any(), any(), any(), any(), any()))
+                .willReturn(searchStoreListResponse);
+
+        // when
+        ResultActions resultActions = performSearchRequest(any(), any(), any(), any(), any());
+
+        // then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isOk())
+                .andDo(
+                        restDocs.document(
+                                queryParameters(
+                                        parameterWithName("mLat").description("현재 사용자 위치 위도"),
+                                        parameterWithName("mLng").description("현재 사용자 위치 경도"),
+                                        parameterWithName("rLat").description("검색 반경 위도"),
+                                        parameterWithName("rLng").description("검색 반경 경도"),
+                                        parameterWithName("foodType").description("음식 타입")
+                                ),
+                                responseFields(
+                                        fieldWithPath("results").description("검색 결과 목록"),
+                                        fieldWithPath("results[].id").description("가게 ID"),
+                                        fieldWithPath("results[].name").description("가게 이름"),
+                                        fieldWithPath("results[].storeType").description("가게 타입"),
+                                        fieldWithPath("results[].detailLocation").description("가게 상세 위치"),
+                                        fieldWithPath("results[].averageRating").description("가게 평균 평점"),
+                                        fieldWithPath("results[].businessDate").description("가게 영업 요일"),
+                                        fieldWithPath("results[].imageUrl").description("가게 이미지 URL"),
+                                        fieldWithPath("results[].lat").description("가게 위도"),
+                                        fieldWithPath("results[].lng").description("가게 경도"),
+                                        fieldWithPath("results[].streetAddress").description("가게 주소"),
+                                        fieldWithPath("results[].distanceFromStore").description("가게까지의 거리"),
+                                        fieldWithPath("results[].storeCategories").description("가게의 카테고리 정보"),
+                                        fieldWithPath("results[].storeCategories.categories").description("가게 음식 카테고리 목록"),
+                                        fieldWithPath("results[].storeCategories.categories[].id").description("음식 카테고리 ID"),
+                                        fieldWithPath("results[].storeCategories.categories[].foodType").description("음식 타입")
+                                )
+                        )
+                ).andReturn();
+
+        SearchStoreListResponse response = objectMapper.readValue(
+                mvcResult.getResponse().getContentAsString(),
+                SearchStoreListResponse.class
+        );
+
+        assertThat(response).usingRecursiveComparison()
+                .isEqualTo(searchStoreListResponse);
+
+        then(searchService).should(times(1))
+                .searchByLatLngAndFoodCategories(any(), any(), any(), any(), any());
+    }
+
+}

--- a/src/test/java/com/pd/gilgeorigoreuda/search/controller/SearchControllerTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/search/controller/SearchControllerTest.java
@@ -19,13 +19,9 @@ import static org.mockito.BDDMockito.*;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.http.HttpHeaders.*;
-import static org.springframework.http.MediaType.*;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.headers.HeaderDocumentation.*;
 import static org.assertj.core.api.Assertions.*;
 
 @WebMvcTest(SearchController.class)

--- a/src/test/java/com/pd/gilgeorigoreuda/settings/fixtures/FoodCategoryFixtures.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/settings/fixtures/FoodCategoryFixtures.java
@@ -35,4 +35,18 @@ public class FoodCategoryFixtures {
                 .build();
     }
 
+    public static FoodCategory TACOYAKI_CATEGORY() {
+        return FoodCategory.builder()
+                .id(5L)
+                .foodType(FoodType.of("타코야끼").getFoodName())
+                .build();
+    }
+
+    public static FoodCategory TANGHURU_CATEGORY() {
+        return FoodCategory.builder()
+                .id(6L)
+                .foodType(FoodType.of("탕후루").getFoodName())
+                .build();
+    }
+
 }

--- a/src/test/java/com/pd/gilgeorigoreuda/settings/fixtures/StoreFixtures.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/settings/fixtures/StoreFixtures.java
@@ -62,4 +62,76 @@ public class StoreFixtures {
                 .build();
     }
 
+    public static Store TTEOKBOKKI() {
+        return Store.builder()
+                .id(3L)
+                .name("강남역 4번 출구 떡볶이 가게")
+                .storeType(FOOD_STALL)
+                .detailLocation("강남역 4번 출구 10M 앞")
+                .averageRating(3.5)
+                .businessDate("monday,tuesday,wednesday,thursday,friday,saturday")
+                .openTime(LocalTime.of(10, 0))
+                .closeTime(LocalTime.of(20, 0))
+                .purchaseType(CARD)
+                .imageUrl("https://image3.com")
+                .lat(new BigDecimal("37.49677886297113"))
+                .lng(new BigDecimal("127.02847474323126"))
+                .streetAddress(StreetAddress.of("서울특별시 강남구 강남대로 453"))
+                .totalVisitCount(50)
+                .lastModifiedMemberNickname("nickname1")
+                .member(KIM())
+                .foodCategories(new ArrayList<>(List.of(TTEOKBOKKI_CATEGORY())))
+                .totalReportCount(0)
+                .isBlocked(false)
+                .build();
+    }
+
+    public static Store TACOYAKI() {
+        return Store.builder()
+                .id(4L)
+                .name("강남역 5번 출구 타코야끼 가게")
+                .storeType(FOOD_STALL)
+                .detailLocation("강남역 5번 출구 10M 앞")
+                .averageRating(3.5)
+                .businessDate("monday,tuesday,wednesday,thursday,friday,saturday")
+                .openTime(LocalTime.of(10, 0))
+                .closeTime(LocalTime.of(20, 0))
+                .purchaseType(CARD)
+                .imageUrl("https://image4.com")
+                .lat(new BigDecimal("37.49677886297113"))
+                .lng(new BigDecimal("127.02847474323126"))
+                .streetAddress(StreetAddress.of("서울특별시 강남구 강남대로 453"))
+                .totalVisitCount(50)
+                .lastModifiedMemberNickname("nickname2")
+                .member(LEE())
+                .foodCategories(new ArrayList<>(List.of(TACOYAKI_CATEGORY())))
+                .totalReportCount(0)
+                .isBlocked(false)
+                .build();
+    }
+
+    public static Store TANGHURU() {
+        return Store.builder()
+                .id(5L)
+                .name("강남역 6번 출구 탕후루 가게")
+                .storeType(FOOD_STALL)
+                .detailLocation("강남역 6번 출구 10M 앞")
+                .averageRating(3.5)
+                .businessDate("monday,tuesday,wednesday,thursday,friday,saturday")
+                .openTime(LocalTime.of(10, 0))
+                .closeTime(LocalTime.of(20, 0))
+                .purchaseType(CARD)
+                .imageUrl("https://image5.com")
+                .lat(new BigDecimal("37.49677886297113"))
+                .lng(new BigDecimal("127.02847474323126"))
+                .streetAddress(StreetAddress.of("서울특별시 강남구 강남대로 453"))
+                .totalVisitCount(50)
+                .lastModifiedMemberNickname("nickname2")
+                .member(LEE())
+                .foodCategories(new ArrayList<>(List.of(TANGHURU_CATEGORY())))
+                .totalReportCount(0)
+                .isBlocked(false)
+                .build();
+    }
+
 }

--- a/src/test/java/com/pd/gilgeorigoreuda/store/controller/StoreControllerTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/store/controller/StoreControllerTest.java
@@ -84,7 +84,7 @@ class StoreControllerTest extends ControllerTest {
                 get("/api/v1/stores/{storeId}", storeId)
                         .param("lat", lat)
                         .param("lng", lng)
-                .header(AUTHORIZATION, MEMBER_ACCESS_REFRESH_TOKEN.getAccessToken())
+                        .header(AUTHORIZATION, MEMBER_ACCESS_REFRESH_TOKEN.getAccessToken())
                         .contentType(APPLICATION_JSON)
         );
     }
@@ -92,7 +92,7 @@ class StoreControllerTest extends ControllerTest {
     private ResultActions performPostRequest(final StoreCreateRequest storeCreateRequest) throws Exception {
         return mockMvc.perform(
                 post("/api/v1/stores")
-                .header(AUTHORIZATION, MEMBER_ACCESS_REFRESH_TOKEN.getAccessToken())
+                        .header(AUTHORIZATION, MEMBER_ACCESS_REFRESH_TOKEN.getAccessToken())
                         .contentType(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(storeCreateRequest))
         );
@@ -101,7 +101,7 @@ class StoreControllerTest extends ControllerTest {
     private ResultActions performPutRequest(final StoreUpdateRequest storeUpdateRequest, final Long storeId) throws Exception {
         return mockMvc.perform(
                 put("/api/v1/stores/{storeId}", storeId)
-                .header(AUTHORIZATION, MEMBER_ACCESS_REFRESH_TOKEN.getAccessToken())
+                        .header(AUTHORIZATION, MEMBER_ACCESS_REFRESH_TOKEN.getAccessToken())
                         .contentType(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(storeUpdateRequest))
         );
@@ -110,7 +110,7 @@ class StoreControllerTest extends ControllerTest {
     private ResultActions performDeleteRequest(final Long storeId) throws Exception {
         return mockMvc.perform(
                 delete("/api/v1/stores/{storeId}", storeId)
-                .header(AUTHORIZATION, MEMBER_ACCESS_REFRESH_TOKEN.getAccessToken())
+                        .header(AUTHORIZATION, MEMBER_ACCESS_REFRESH_TOKEN.getAccessToken())
                         .contentType(APPLICATION_JSON)
         );
     }


### PR DESCRIPTION
## 🔥 연관 이슈
- close: #391 

## 📝 작업 요약
검색 컨트롤러 테스트를 작성하고 문서화 진행

## 🔎 작업 상세 설명
1. SearchController에서 주변 가게 검색 기능을 테스트 
2. mockMvc를 사용하여 검색 요청을 수행하고, Mockito를 활용하여 서비스의 응답을 설정
3. 그 후 검색 결과 문서화 진행

## 🌟 리뷰 요구 사항

