### PR TITLE
test/#393 SearchService 단위 테스트 작성

### DIFF
--- a/src/main/java/com/pd/gilgeorigoreuda/search/repository/SearchRepository.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/search/repository/SearchRepository.java
@@ -10,11 +10,18 @@ import java.util.List;
 
 public interface SearchRepository extends JpaRepository<Store, Long> {
 
-        @Query("SELECT s FROM Store s " +
-                "LEFT JOIN FETCH s.foodCategories fc " +
-                "WHERE FUNCTION('acos', FUNCTION('cos', FUNCTION('radians', :lat)) * FUNCTION('cos', FUNCTION('radians', s.lat)) * FUNCTION('cos', FUNCTION('radians', :lng) - FUNCTION('radians', s.lng)) + FUNCTION('sin', FUNCTION('radians', :lat)) * FUNCTION('sin', FUNCTION('radians', s.lat))) " +
-                "* 6371 * 1000 <= :boundary " +
-                "AND (:foodType IS NULL OR fc.foodType = :foodType)"
+        @Query(
+                """
+                SELECT s FROM Store s \s
+                LEFT JOIN FETCH s.foodCategories fc \s
+                WHERE \s
+                    FUNCTION('acos', \s
+                        FUNCTION('cos', FUNCTION('radians', :lat)) * FUNCTION('cos', FUNCTION('radians', s.lat)) * \s
+                        FUNCTION('cos', FUNCTION('radians', :lng) - FUNCTION('radians', s.lng)) + \s
+                        FUNCTION('sin', FUNCTION('radians', :lat)) * FUNCTION('sin', FUNCTION('radians', s.lat))\s
+                    ) * 6371 * 1000 <= :boundary \s
+                    AND (:foodType IS NULL OR fc.foodType = :foodType) \s
+                """
         )
         List<Store> searchStoresByLatLngAndFoodType(
                 @Param("lat") final BigDecimal lat,

--- a/src/test/java/com/pd/gilgeorigoreuda/search/service/SearchServiceTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/search/service/SearchServiceTest.java
@@ -1,0 +1,72 @@
+package com.pd.gilgeorigoreuda.search.service;
+
+import com.pd.gilgeorigoreuda.search.dto.response.SearchStoreListResponse;
+import com.pd.gilgeorigoreuda.search.dto.response.SearchStoreResponse;
+import com.pd.gilgeorigoreuda.settings.ServiceTest;
+import com.pd.gilgeorigoreuda.settings.fixtures.StoreFixtures;
+import com.pd.gilgeorigoreuda.store.domain.entity.FoodType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static com.pd.gilgeorigoreuda.settings.fixtures.StoreFixtures.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.SoftAssertions.*;
+import static org.mockito.BDDMockito.*;
+
+class SearchServiceTest extends ServiceTest {
+
+    private static final Integer BOUNDARY_1KM = 1000;
+
+    private static final BigDecimal MEMBER_LAT = new BigDecimal("37.49732853932101");
+    private static final BigDecimal MEMBER_LNG = new BigDecimal("127.02821485508554");
+    private static final BigDecimal REFERENCE_LAT = new BigDecimal("37.49732853932101");
+    private static final BigDecimal REFERENCE_LNG = new BigDecimal("127.02821485508554");
+    private static final String FOOD_TYPE = FoodType.of("붕어빵").getFoodName();
+
+    @Test
+    @DisplayName("사용자의 위치 기준 반경 1KM 내의 음식점 목록을 조회")
+    void searchByLatLngAndFoodCategories() {
+        // given
+        given(
+                searchRepository.searchStoresByLatLngAndFoodType(
+                        any(BigDecimal.class),
+                        any(BigDecimal.class),
+                        anyString(),
+                        any(Integer.class)
+                )
+        ).willReturn(List.of(BUNGEOPPANG(), ODENG(), TTEOKBOKKI()));
+
+        // when
+        SearchStoreListResponse searchStoreListResponse = searchService.searchByLatLngAndFoodCategories(
+                MEMBER_LAT,
+                MEMBER_LNG,
+                REFERENCE_LAT,
+                REFERENCE_LNG,
+                FOOD_TYPE
+        );
+
+        // then
+        assertSoftly(
+                softly -> {
+                    assertThat(searchStoreListResponse.getResults()).hasSize(3);
+                    then(searchRepository).should(times(1)).searchStoresByLatLngAndFoodType(
+                            any(BigDecimal.class),
+                            any(BigDecimal.class),
+                            anyString(),
+                            any(Integer.class)
+                    );
+
+                    then(distanceCalculator).should(times(3)).getDistance(
+                            any(BigDecimal.class),
+                            any(BigDecimal.class),
+                            any(BigDecimal.class),
+                            any(BigDecimal.class)
+                    );
+                }
+        );
+    }
+
+}

--- a/src/test/java/com/pd/gilgeorigoreuda/settings/ServiceTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/settings/ServiceTest.java
@@ -10,6 +10,8 @@ import com.pd.gilgeorigoreuda.login.repository.MemberTokenRepository;
 import com.pd.gilgeorigoreuda.login.service.LoginService;
 import com.pd.gilgeorigoreuda.member.repository.MemberActiveInfoRepository;
 import com.pd.gilgeorigoreuda.member.repository.MemberRepository;
+import com.pd.gilgeorigoreuda.search.repository.SearchRepository;
+import com.pd.gilgeorigoreuda.search.service.SearchService;
 import com.pd.gilgeorigoreuda.store.repository.StoreNativeQueryRepository;
 import com.pd.gilgeorigoreuda.store.repository.StoreRepository;
 import com.pd.gilgeorigoreuda.store.service.StoreService;
@@ -36,6 +38,9 @@ public abstract class ServiceTest {
 
     @InjectMocks
     protected LoginService loginService;
+
+    @InjectMocks
+    protected SearchService searchService;
 
     // Mock 객체
     @Mock
@@ -76,5 +81,8 @@ public abstract class ServiceTest {
 
     @Mock
     protected BearerTokenExtractor bearerExtractor;
+
+    @Mock
+    protected SearchRepository searchRepository;
 
 }


### PR DESCRIPTION
## 🔥 연관 이슈
- close: #393

## 📝 작업 요약
1. SearchService 단위 테스트 작성
2. SearchRepository의 메서드의 쿼리문이 수정

## 🔎 작업 상세 설명
1. SearchRepository의 searchStoresByLatLngAndFoodType 쿼리문 가독성을 높이기 위해 변경
2. SearchService 단위 테스트 작성

## 🌟 리뷰 요구 사항

