### PR TITLE
test/#397 가게 좋아요, 싫어요 서비스 단위 테스트

### DIFF
--- a/src/main/java/com/pd/gilgeorigoreuda/store/controller/StorePreferenceController.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/store/controller/StorePreferenceController.java
@@ -20,7 +20,7 @@ public class StorePreferenceController {
     public ResponseEntity<Void> addStoreLike(
             @PathVariable Long storeId,
             @MemberInfo final LoginMember loginMember) {
-        storePreferenceService.addStoreLike(storeId, loginMember.getMemberId());
+        storePreferenceService.storeLike(storeId, loginMember.getMemberId());
 
         return ResponseEntity
                 .ok()
@@ -32,7 +32,7 @@ public class StorePreferenceController {
     public ResponseEntity<Void> addStoreHate(
             @PathVariable Long storeId,
             @MemberInfo final LoginMember loginMember) {
-        storePreferenceService.addStoreHate(storeId, loginMember.getMemberId());
+        storePreferenceService.storeHate(storeId, loginMember.getMemberId());
 
         return ResponseEntity
                 .ok()

--- a/src/main/java/com/pd/gilgeorigoreuda/store/domain/entity/StorePreference.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/store/domain/entity/StorePreference.java
@@ -45,7 +45,7 @@ public class StorePreference extends BaseTimeEntity {
 	@JoinColumn(name = "member_id", foreignKey = @ForeignKey(name = "fk_store_preferences_member_id"))
 	private Member member;
 
-	public void changePreference(StorePreferenceType preferenceType) {
+	public void changePreference(final StorePreferenceType preferenceType) {
 		this.preferenceType = preferenceType;
 	}
 

--- a/src/main/java/com/pd/gilgeorigoreuda/store/service/StorePreferenceService.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/store/service/StorePreferenceService.java
@@ -9,46 +9,50 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
+import static com.pd.gilgeorigoreuda.store.domain.entity.StorePreferenceType.*;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class StorePreferenceService {
 
     private final StorePreferenceRepository storePreferenceRepository;
 
-    public void addStoreLike(Long storeId, Long memberId) {
-        Optional<StorePreference> storePreference = storePreferenceRepository.findByStoreIdAndMemberId(storeId, memberId);
-
-        changePreferenceStatus(storePreference, StorePreferenceType.PREFERRED, storeId, memberId);
+    @Transactional
+    public void storeLike(final Long storeId, final Long memberId) {
+        storePreferenceRepository.findByStoreIdAndMemberId(storeId, memberId)
+                        .ifPresentOrElse(
+                                storePreference -> changePreferenceStatus(storePreference, PREFERRED),
+                                () -> saveStorePreference(PREFERRED, storeId, memberId)
+                        );
     }
 
-    public void addStoreHate(Long storeId, Long memberId){
-        Optional<StorePreference> storePreference = storePreferenceRepository.findByStoreIdAndMemberId(storeId, memberId);
+    @Transactional
+    public void storeHate(final Long storeId, final Long memberId){
+        storePreferenceRepository.findByStoreIdAndMemberId(storeId, memberId)
+                .ifPresentOrElse(
+                        storePreference -> changePreferenceStatus(storePreference, NOT_PREFERRED),
+                        () -> saveStorePreference(NOT_PREFERRED, storeId, memberId)
+                );
 
-        changePreferenceStatus(storePreference, StorePreferenceType.NOT_PREFERRED, storeId, memberId);
     }
 
+    private void changePreferenceStatus(final StorePreference storePreference, final StorePreferenceType type) {
+        if (storePreference.getPreferenceType().equals(type)) {
+            storePreference.changePreference(NONE);
+        } else {
+            storePreference.changePreference(type);
+        }
+    }
 
-    private void changePreferenceStatus(Optional<StorePreference> storePreference, StorePreferenceType type, Long storeId, Long memberId) {
-        storePreference.ifPresentOrElse(
-                existingStorePreference -> {
-                    if (existingStorePreference.getPreferenceType().equals(type)) {
-                        existingStorePreference.changePreference(StorePreferenceType.NONE);
-                    } else {
-                        existingStorePreference.changePreference(type);
-                    }
-                },
-                () -> {
-                    storePreferenceRepository.save(
-                            StorePreference.builder()
-                                    .store(Store.builder().id(storeId).build())
-                                    .member(Member.builder().id(memberId).build())
-                                    .preferenceType(type)
-                                    .build()
-                    );
-                }
+    private void saveStorePreference (final StorePreferenceType type, final Long storeId, final Long memberId) {
+        storePreferenceRepository.save(
+                StorePreference.builder()
+                        .store(Store.builder().id(storeId).build())
+                        .member(Member.builder().id(memberId).build())
+                        .preferenceType(type)
+                        .build()
         );
     }
+
 }

--- a/src/test/java/com/pd/gilgeorigoreuda/settings/ServiceTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/settings/ServiceTest.java
@@ -13,13 +13,16 @@ import com.pd.gilgeorigoreuda.member.repository.MemberRepository;
 import com.pd.gilgeorigoreuda.search.repository.SearchRepository;
 import com.pd.gilgeorigoreuda.search.service.SearchService;
 import com.pd.gilgeorigoreuda.store.repository.StoreNativeQueryRepository;
+import com.pd.gilgeorigoreuda.store.repository.StorePreferenceRepository;
 import com.pd.gilgeorigoreuda.store.repository.StoreRepository;
+import com.pd.gilgeorigoreuda.store.service.StorePreferenceService;
 import com.pd.gilgeorigoreuda.store.service.StoreService;
 import com.pd.gilgeorigoreuda.visit.repository.StoreVisitRecordRepository;
 import com.pd.gilgeorigoreuda.visit.service.VisitService;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,6 +44,9 @@ public abstract class ServiceTest {
 
     @InjectMocks
     protected SearchService searchService;
+
+    @InjectMocks
+    protected StorePreferenceService storePreferenceService;
 
     // Mock 객체
     @Mock
@@ -84,5 +90,8 @@ public abstract class ServiceTest {
 
     @Mock
     protected SearchRepository searchRepository;
+
+    @Mock
+    protected StorePreferenceRepository storePreferenceRepository;
 
 }

--- a/src/test/java/com/pd/gilgeorigoreuda/settings/fixtures/StorePreferenceFixtures.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/settings/fixtures/StorePreferenceFixtures.java
@@ -1,0 +1,59 @@
+package com.pd.gilgeorigoreuda.settings.fixtures;
+
+import com.pd.gilgeorigoreuda.store.domain.entity.StorePreference;
+
+import static com.pd.gilgeorigoreuda.settings.fixtures.MemberFixtures.*;
+import static com.pd.gilgeorigoreuda.settings.fixtures.StoreFixtures.*;
+import static com.pd.gilgeorigoreuda.store.domain.entity.StorePreferenceType.*;
+
+public class StorePreferenceFixtures {
+
+    public static StorePreference BUNGEOPPANG_PREFERENCE_PREFERRED() {
+        return StorePreference.builder()
+                .store(BUNGEOPPANG())
+                .member(LEE())
+                .preferenceType(PREFERRED)
+                .build();
+    }
+
+    public static StorePreference BUNGEOPPANG_PREFERENCE_NONE() {
+        return StorePreference.builder()
+                .store(BUNGEOPPANG())
+                .member(LEE())
+                .preferenceType(NONE)
+                .build();
+    }
+
+    public static StorePreference BUNGEOPPANG_PREFERENCE_NOT_PREFERRED() {
+        return StorePreference.builder()
+                .store(BUNGEOPPANG())
+                .member(LEE())
+                .preferenceType(NOT_PREFERRED)
+                .build();
+    }
+
+    public static StorePreference ODENG_PREFERENCE_PREFERRED() {
+        return StorePreference.builder()
+                .store(ODENG())
+                .member(KIM())
+                .preferenceType(PREFERRED)
+                .build();
+    }
+
+    public static StorePreference ODENG_PREFERENCE_NONE() {
+        return StorePreference.builder()
+                .store(ODENG())
+                .member(KIM())
+                .preferenceType(NONE)
+                .build();
+    }
+
+    public static StorePreference ODENG_PREFERENCE_NOT_PREFERRED() {
+        return StorePreference.builder()
+                .store(ODENG())
+                .member(KIM())
+                .preferenceType(NOT_PREFERRED)
+                .build();
+    }
+
+}

--- a/src/test/java/com/pd/gilgeorigoreuda/store/controller/StorePreferenceControllerTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/store/controller/StorePreferenceControllerTest.java
@@ -61,7 +61,7 @@ class StorePreferenceControllerTest extends ControllerTest {
         Long storeId = 1L;
         Long memberId = MEMBER_TOKEN.getMemberId();
 
-        doNothing().when(storePreferenceService).addStoreLike(storeId, memberId);
+        doNothing().when(storePreferenceService).storeLike(storeId, memberId);
 
         // when
         ResultActions resultActions = performPostLikeRequest(storeId);
@@ -77,7 +77,7 @@ class StorePreferenceControllerTest extends ControllerTest {
                         )
                 );
 
-        then(storePreferenceService).should(times(1)).addStoreLike(storeId, memberId);
+        then(storePreferenceService).should(times(1)).storeLike(storeId, memberId);
     }
 
     @Test
@@ -87,7 +87,7 @@ class StorePreferenceControllerTest extends ControllerTest {
         Long storeId = 1L;
         Long memberId = MEMBER_TOKEN.getMemberId();
 
-        doNothing().when(storePreferenceService).addStoreHate(storeId, memberId);
+        doNothing().when(storePreferenceService).storeHate(storeId, memberId);
 
         // when
         ResultActions resultActions = performPostHateRequest(storeId);
@@ -103,7 +103,7 @@ class StorePreferenceControllerTest extends ControllerTest {
                         )
                 );
 
-        then(storePreferenceService).should(times(1)).addStoreHate(storeId, memberId);
+        then(storePreferenceService).should(times(1)).storeHate(storeId, memberId);
     }
 
 }

--- a/src/test/java/com/pd/gilgeorigoreuda/store/service/StorePreferenceServiceTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/store/service/StorePreferenceServiceTest.java
@@ -1,0 +1,221 @@
+package com.pd.gilgeorigoreuda.store.service;
+
+import com.pd.gilgeorigoreuda.settings.ServiceTest;
+import com.pd.gilgeorigoreuda.store.domain.entity.StorePreference;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static com.pd.gilgeorigoreuda.settings.fixtures.StorePreferenceFixtures.*;
+import static com.pd.gilgeorigoreuda.store.domain.entity.StorePreferenceType.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.SoftAssertions.*;
+import static org.mockito.BDDMockito.*;
+
+class StorePreferenceServiceTest extends ServiceTest {
+
+    @Nested
+    @DisplayName("가게 좋아요")
+    class StoreLikeTest {
+
+        @Test
+        @DisplayName("가게 좋아요 정보가 없다면 가게 좋아요 생성 후 저장")
+        void saveStorePreferenceWhenNotExists() {
+            // given
+            given(storePreferenceRepository.findByStoreIdAndMemberId(any(), any()))
+                    .willReturn(Optional.empty());
+
+            // when
+            storePreferenceService.storeLike(anyLong(), anyLong());
+
+            // then
+            assertSoftly(softly -> {
+                then(storePreferenceRepository).should().findByStoreIdAndMemberId(any(), any());
+                then(storePreferenceRepository).should().save(any());
+            });
+        }
+
+        @Test
+        @DisplayName("가게 좋아요 정보가 있다면 가게 좋아요 정보 변경 - PREFERRED -> NONE")
+        void changeStorePreferenceWhenPreferred() {
+            // given
+            StorePreference preferencePreferred = BUNGEOPPANG_PREFERENCE_PREFERRED();
+            Long storeId = preferencePreferred.getStore().getId();
+            Long memberId = preferencePreferred.getMember().getId();
+
+            given(storePreferenceRepository.findByStoreIdAndMemberId(any(), any()))
+                    .willReturn(Optional.of(preferencePreferred));
+
+            // when
+            storePreferenceService.storeLike(storeId, memberId);
+
+            // then
+            assertSoftly(softly -> {
+                then(storePreferenceRepository).should().findByStoreIdAndMemberId(any(), any());
+                then(storePreferenceRepository).should(never()).save(preferencePreferred);
+            });
+
+            storePreferenceRepository.findByStoreIdAndMemberId(storeId, memberId)
+                    .ifPresent(storePreference -> {
+                        assertThat(storePreference.getPreferenceType()).isEqualTo(NONE);
+                    });
+        }
+
+        @Test
+        @DisplayName("가게 좋아요 정보가 있다면 가게 좋아요 정보 변경 - NONE -> PREFERRED")
+        void changeStorePreferenceWhenNone() {
+            // given
+            StorePreference preferenceNone = BUNGEOPPANG_PREFERENCE_NONE();
+            Long storeId = preferenceNone.getStore().getId();
+            Long memberId = preferenceNone.getMember().getId();
+
+            given(storePreferenceRepository.findByStoreIdAndMemberId(any(), any()))
+                    .willReturn(Optional.of(preferenceNone));
+
+            // when
+            storePreferenceService.storeLike(storeId, memberId);
+
+            // then
+            assertSoftly(softly -> {
+                then(storePreferenceRepository).should().findByStoreIdAndMemberId(any(), any());
+                then(storePreferenceRepository).should(never()).save(preferenceNone);
+            });
+
+            storePreferenceRepository.findByStoreIdAndMemberId(storeId, memberId)
+                    .ifPresent(storePreference -> {
+                        assertThat(storePreference.getPreferenceType()).isEqualTo(PREFERRED);
+                    });
+        }
+
+        @Test
+        @DisplayName("가게 싫어요 정보가 있다면 가게 좋아요 정보 변경 - NOT_PREFERRED -> PREFERRED")
+        void changeStorePreferenceWhenNotPreferred() {
+            // given
+            StorePreference preferenceNotPreferred = BUNGEOPPANG_PREFERENCE_NOT_PREFERRED();
+            Long storeId = preferenceNotPreferred.getStore().getId();
+            Long memberId = preferenceNotPreferred.getMember().getId();
+
+            given(storePreferenceRepository.findByStoreIdAndMemberId(any(), any()))
+                    .willReturn(Optional.of(preferenceNotPreferred));
+
+            // when
+            storePreferenceService.storeLike(storeId, memberId);
+
+            // then
+            assertSoftly(softly -> {
+                then(storePreferenceRepository).should().findByStoreIdAndMemberId(any(), any());
+                then(storePreferenceRepository).should(never()).save(preferenceNotPreferred);
+            });
+
+            storePreferenceRepository.findByStoreIdAndMemberId(storeId, memberId)
+                    .ifPresent(storePreference -> {
+                        assertThat(storePreference.getPreferenceType()).isEqualTo(PREFERRED);
+                    });
+        }
+
+    }
+
+    @Nested
+    @DisplayName("가게 싫어요")
+    class StoreHateTest {
+
+        @Test
+        @DisplayName("가게 싫어요 정보가 없다면 가게 싫어요 생성 후 저장")
+        void saveStorePreferenceWhenNotExists() {
+            // given
+            given(storePreferenceRepository.findByStoreIdAndMemberId(any(), any()))
+                    .willReturn(Optional.empty());
+
+            // when
+            storePreferenceService.storeHate(anyLong(), anyLong());
+
+            // then
+            assertSoftly(softly -> {
+                then(storePreferenceRepository).should().findByStoreIdAndMemberId(any(), any());
+                then(storePreferenceRepository).should().save(any());
+            });
+        }
+
+        @Test
+        @DisplayName("가게 싫어요 정보가 있다면 가게 싫어요 정보 변경 - NOT_PREFERRED -> NONE")
+        void changeStorePreferenceWhenNotPreferred() {
+            // given
+            StorePreference preferenceNotPreferred = ODENG_PREFERENCE_NOT_PREFERRED();
+            Long storeId = preferenceNotPreferred.getStore().getId();
+            Long memberId = preferenceNotPreferred.getMember().getId();
+
+            given(storePreferenceRepository.findByStoreIdAndMemberId(any(), any()))
+                    .willReturn(Optional.of(preferenceNotPreferred));
+
+            // when
+            storePreferenceService.storeHate(storeId, memberId);
+
+            // then
+            assertSoftly(softly -> {
+                then(storePreferenceRepository).should().findByStoreIdAndMemberId(any(), any());
+                then(storePreferenceRepository).should(never()).save(preferenceNotPreferred);
+            });
+
+            storePreferenceRepository.findByStoreIdAndMemberId(storeId, memberId)
+                    .ifPresent(storePreference -> {
+                        assertThat(storePreference.getPreferenceType()).isEqualTo(NONE);
+                    });
+        }
+
+        @Test
+        @DisplayName("가게 싫어요 정보가 있다면 가게 싫어요 정보 변경 - NONE -> NOT_PREFERRED")
+        void changeStorePreferenceWhenNone() {
+            // given
+            StorePreference preferenceNone = ODENG_PREFERENCE_NONE();
+            Long storeId = preferenceNone.getStore().getId();
+            Long memberId = preferenceNone.getMember().getId();
+
+            given(storePreferenceRepository.findByStoreIdAndMemberId(any(), any()))
+                    .willReturn(Optional.of(preferenceNone));
+
+            // when
+            storePreferenceService.storeHate(storeId, memberId);
+
+            // then
+            assertSoftly(softly -> {
+                then(storePreferenceRepository).should().findByStoreIdAndMemberId(any(), any());
+                then(storePreferenceRepository).should(never()).save(preferenceNone);
+            });
+
+            storePreferenceRepository.findByStoreIdAndMemberId(storeId, memberId)
+                    .ifPresent(storePreference -> {
+                        assertThat(storePreference.getPreferenceType()).isEqualTo(NOT_PREFERRED);
+                    });
+        }
+
+        @Test
+        @DisplayName("가게 좋아요 정보가 있다면 가게 싫어요 정보 변경 - PREFERRED -> NOT_PREFERRED")
+        void changeStorePreferenceWhenPreferred() {
+            // given
+            StorePreference preferencePreferred = ODENG_PREFERENCE_PREFERRED();
+            Long storeId = preferencePreferred.getStore().getId();
+            Long memberId = preferencePreferred.getMember().getId();
+
+            given(storePreferenceRepository.findByStoreIdAndMemberId(any(), any()))
+                    .willReturn(Optional.of(preferencePreferred));
+
+            // when
+            storePreferenceService.storeHate(storeId, memberId);
+
+            // then
+            assertSoftly(softly -> {
+                then(storePreferenceRepository).should().findByStoreIdAndMemberId(any(), any());
+                then(storePreferenceRepository).should(never()).save(preferencePreferred);
+            });
+
+            storePreferenceRepository.findByStoreIdAndMemberId(storeId, memberId)
+                    .ifPresent(storePreference -> {
+                        assertThat(storePreference.getPreferenceType()).isEqualTo(NOT_PREFERRED);
+                    });
+        }
+
+    }
+
+}


### PR DESCRIPTION
## 🔥 연관 이슈
- close: #397 

## 📝 작업 요약
가게에 대한 사용자의 좋아요 및 싫어요 서비스 테스트 코드를 작성

## 🔎 작업 상세 설명
1. StorePreferenceService 클래스의 storeLike 메서드와 storeHate 메서드에 대한 테스트 코드 작성
2. 각 테스트 케이스에서 가게에 대한 사용자의 선호도가 변경되는 시나리오 검증

## 🌟 리뷰 요구 사항

