### PR TITLE
test/#401 StoreController 단위 테스트 및 API 문서 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -168,3 +168,47 @@ include::{snippets}/store-preference-controller-test/add-store-hate/path-paramet
 
 ==== Response
 include::{snippets}/store-preference-controller-test/add-store-hate/http-response.adoc[]
+
+== 가게 신고 API
+
+=== 가게 신고 생성 (POST /api/v1/reports/stores/{storeId})
+
+==== Request
+include::{snippets}/store-report-controller-test/create-store-report-success/http-request.adoc[]
+include::{snippets}/store-report-controller-test/create-store-report-success/path-parameters.adoc[]
+include::{snippets}/store-report-controller-test/create-store-report-success/request-fields.adoc[]
+include::{snippets}/store-report-controller-test/create-store-report-success/request-headers.adoc[]
+
+==== Response
+include::{snippets}/store-report-controller-test/create-store-report-success/http-response.adoc[]
+
+=== 사용자가 신고한 가게 조회 (GET /api/v1/reports/stores/memberCheck)
+
+==== Request
+include::{snippets}/store-report-controller-test/check-member-report-list/http-request.adoc[]
+include::{snippets}/store-report-controller-test/check-member-report-list/request-headers.adoc[]
+
+==== Response
+include::{snippets}/store-report-controller-test/check-member-report-list/http-response.adoc[]
+include::{snippets}/store-report-controller-test/check-member-report-list/response-fields.adoc[]
+
+== 해당 가게 신고 접수된 리스트 조회 (GET /api/v1/reports/stores/{storeId})
+
+=== Request
+include::{snippets}/store-report-controller-test/check-store-report-list/http-request.adoc[]
+include::{snippets}/store-report-controller-test/check-store-report-list/path-parameters.adoc[]
+include::{snippets}/store-report-controller-test/check-store-report-list/request-headers.adoc[]
+
+=== Response
+include::{snippets}/store-report-controller-test/check-store-report-list/http-response.adoc[]
+include::{snippets}/store-report-controller-test/check-store-report-list/response-fields.adoc[]
+
+== 가게 신고 내역 삭제 (DELETE /api/v1/reports/stores/{storeId})
+
+=== Request
+include::{snippets}/store-report-controller-test/delete-store-report-success/http-request.adoc[]
+include::{snippets}/store-report-controller-test/delete-store-report-success/path-parameters.adoc[]
+include::{snippets}/store-report-controller-test/delete-store-report-success/request-headers.adoc[]
+
+=== Response
+include::{snippets}/store-report-controller-test/delete-store-report-success/http-response.adoc[]

--- a/src/main/java/com/pd/gilgeorigoreuda/store/controller/StoreReportController.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/store/controller/StoreReportController.java
@@ -6,6 +6,7 @@ import com.pd.gilgeorigoreuda.auth.domain.LoginMember;
 import com.pd.gilgeorigoreuda.store.dto.request.ReportCreateRequest;
 import com.pd.gilgeorigoreuda.store.dto.response.StoreReportHistoryListResponse;
 import com.pd.gilgeorigoreuda.store.service.StoreReportService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,12 +20,12 @@ public class StoreReportController {
 
     @MemberOnly
     @PostMapping("/stores/{storeId}")
-    public ResponseEntity<Void> addStoreReport(
+    public ResponseEntity<Void> createStoreReport(
             @PathVariable final Long storeId,
             @MemberInfo final LoginMember loginMember,
-            @RequestBody final ReportCreateRequest reportCreateRequest
+            @Valid @RequestBody final ReportCreateRequest reportCreateRequest
     ) {
-        storeReportService.addStoreReport(reportCreateRequest, storeId, loginMember.getMemberId());
+        storeReportService.createStoreReport(reportCreateRequest, storeId, loginMember.getMemberId());
 
         return ResponseEntity
                 .ok()
@@ -48,7 +49,6 @@ public class StoreReportController {
     @GetMapping("/stores/memberCheck")
     public ResponseEntity<StoreReportHistoryListResponse> checkMemberReportList(
             @MemberInfo final LoginMember loginMember
-
     ) {
         StoreReportHistoryListResponse storeReportHistoryListResponse =
                 storeReportService.checkMemberReportList(loginMember.getMemberId());

--- a/src/main/java/com/pd/gilgeorigoreuda/store/dto/request/ReportCreateRequest.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/store/dto/request/ReportCreateRequest.java
@@ -14,7 +14,7 @@ import java.math.BigDecimal;
 public class ReportCreateRequest {
 
     @NotBlank(message = "신고 내용을 입력해주세요.")
-    @Size(min = 1, max = 300, message = "신고 내용은 1에서 300자 사이여야 합니다.")
+    @Size(max = 300, message = "신고 내용은 1에서 300자 사이여야 합니다.")
     private String content;
 
     @NotNull(message = "위도를 입력해주세요.")

--- a/src/main/java/com/pd/gilgeorigoreuda/store/dto/request/StoreCreateRequest.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/store/dto/request/StoreCreateRequest.java
@@ -23,7 +23,7 @@ public class StoreCreateRequest {
 
 	// todo: validateMessage 분리
 	@NotBlank(message = "가게 이름을 입력해주세요.")
-	@Size(min = 1, max = 50, message = "가게 이름은 1에서 50자 사이여야 합니다.")
+	@Size(max = 50, message = "가게 이름은 1에서 50자 사이여야 합니다.")
 	private String name;
 
 	@NotBlank(message = "가게 타입을 선택해주세요.")

--- a/src/main/java/com/pd/gilgeorigoreuda/store/dto/response/StoreReportHistoryResponse.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/store/dto/response/StoreReportHistoryResponse.java
@@ -1,5 +1,6 @@
 package com.pd.gilgeorigoreuda.store.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.pd.gilgeorigoreuda.store.domain.entity.Store;
 import com.pd.gilgeorigoreuda.store.domain.entity.StoreReportHistory;
 import jakarta.persistence.Column;
@@ -17,15 +18,21 @@ public class StoreReportHistoryResponse {
     private String content;
     private StoreReportMemberResponse member;
     private StoreReportStoreResponse store;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdAt;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime modifiedAt;
 
-    public StoreReportHistoryResponse(final Long id,
-                                      final String content,
-                                      final StoreReportMemberResponse member,
-                                      final StoreReportStoreResponse store,
-                                      final LocalDateTime createdAt,
-                                      final LocalDateTime modifiedAt) {
+    public StoreReportHistoryResponse(
+            final Long id,
+            final String content,
+            final StoreReportMemberResponse member,
+            final StoreReportStoreResponse store,
+            final LocalDateTime createdAt,
+            final LocalDateTime modifiedAt
+    ) {
         this.id = id;
         this.content = content;
         this.member = member;

--- a/src/main/java/com/pd/gilgeorigoreuda/store/service/StoreReportService.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/store/service/StoreReportService.java
@@ -27,7 +27,7 @@ public class StoreReportService {
     private static final Integer BOUNDARY_100M = 100;
 
     @Transactional
-    public void addStoreReport(final ReportCreateRequest reportCreateRequest, final Long storeId, final Long memberId) {
+    public void createStoreReport(final ReportCreateRequest reportCreateRequest, final Long storeId, final Long memberId) {
         checkIsExistStoreReportHistory(storeId, memberId);
 
         Store targetStore = findTargetStore(storeId);

--- a/src/test/java/com/pd/gilgeorigoreuda/store/controller/StoreReportControllerTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/store/controller/StoreReportControllerTest.java
@@ -3,33 +3,46 @@ package com.pd.gilgeorigoreuda.store.controller;
 import com.pd.gilgeorigoreuda.login.domain.MemberAccessRefreshToken;
 import com.pd.gilgeorigoreuda.login.domain.MemberToken;
 import com.pd.gilgeorigoreuda.settings.ControllerTest;
+import com.pd.gilgeorigoreuda.store.dto.request.ReportCreateRequest;
+import com.pd.gilgeorigoreuda.store.dto.response.StoreReportHistoryListResponse;
+import com.pd.gilgeorigoreuda.store.dto.response.StoreReportHistoryResponse;
+import com.pd.gilgeorigoreuda.store.dto.response.StoreReportMemberResponse;
+import com.pd.gilgeorigoreuda.store.dto.response.StoreReportStoreResponse;
 import com.pd.gilgeorigoreuda.store.service.StoreReportService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static com.pd.gilgeorigoreuda.settings.restdocs.RestDocsConfiguration.*;
-import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.http.MediaType.*;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+
 
 @WebMvcTest(StoreReportController.class)
 @AutoConfigureRestDocs
 class StoreReportControllerTest extends ControllerTest {
 
     private static final MemberAccessRefreshToken MEMBER_ACCESS_REFRESH_TOKEN = MemberAccessRefreshToken.of("accessToken", "refreshToken");
-    private static final MemberToken MEMBER_TOKEN = MemberToken.of(1L, "accessToken" ,"refreshToken");
+    private static final MemberToken MEMBER_TOKEN = MemberToken.of(1L, "accessToken", "refreshToken");
 
     @MockBean
     private StoreReportService storeReportService;
@@ -39,6 +52,368 @@ class StoreReportControllerTest extends ControllerTest {
         given(memberTokenRepository.findByAccessToken(any())).willReturn(Optional.of(MEMBER_TOKEN));
         doNothing().when(jwtProvider).validateTokens(any());
         given(jwtProvider.getSubject(any())).willReturn("1");
+    }
+
+    private ResultActions performCheckMemberReportList() throws Exception {
+        return mockMvc.perform(
+                get("/api/v1/reports/stores/memberCheck")
+                        .header(AUTHORIZATION, MEMBER_ACCESS_REFRESH_TOKEN.getAccessToken())
+                        .contentType(APPLICATION_JSON)
+        );
+    }
+
+    private ResultActions performCheckStoreReportList(final Long storeId) throws Exception {
+        return mockMvc.perform(
+                get("/api/v1/reports/stores/storeCheck/{storeId}", storeId)
+                        .header(AUTHORIZATION, MEMBER_ACCESS_REFRESH_TOKEN.getAccessToken())
+                        .contentType(APPLICATION_JSON)
+        );
+    }
+
+    private ResultActions performCreateStoreReport(final ReportCreateRequest reportCreateRequest, final Long storeId) throws Exception {
+        return mockMvc.perform(
+                post("/api/v1/reports/stores/{storeId}", storeId)
+                        .header(AUTHORIZATION, MEMBER_ACCESS_REFRESH_TOKEN.getAccessToken())
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(reportCreateRequest))
+        );
+    }
+
+    private ResultActions performDeleteStoreReport(final Long reportId) throws Exception {
+        return mockMvc.perform(
+                delete("/api/v1/reports/stores/{reportId}", reportId)
+                        .header(AUTHORIZATION, MEMBER_ACCESS_REFRESH_TOKEN.getAccessToken())
+                        .contentType(APPLICATION_JSON)
+        );
+    }
+
+
+    @Test
+    @DisplayName("가게 신고 생성 성공")
+    void createStoreReportSuccess() throws Exception {
+        // given
+        Long storeId = 1L;
+        ReportCreateRequest reportCreateRequest = new ReportCreateRequest(
+                "가게 신고 내용",
+                new BigDecimal("37.123456"),
+                new BigDecimal("127.123456")
+        );
+
+
+        // when
+        ResultActions resultActions = performCreateStoreReport(reportCreateRequest, storeId);
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andDo(
+                        restDocs.document(
+                                pathParameters(
+                                        parameterWithName("storeId").description("가게 ID")
+                                ),
+                                requestHeaders(
+                                        headerWithName(AUTHORIZATION).description("Access Token")
+                                ),
+                                requestFields(
+                                        fieldWithPath("content")
+                                                .type(JsonFieldType.STRING)
+                                                .description("신고 내용")
+                                                .attributes(field("constraints", "1에서 300자 사이")),
+                                        fieldWithPath("memberLat")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("사용자 위치 위도")
+                                                .attributes(field("constraint", "BigDecimal(3, 13)")),
+                                        fieldWithPath("memberLng")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("사용자 위치 경도")
+                                                .attributes(field("constraint", "BigDecimal(3, 13)"))
+                                )
+                        )
+                );
+
+        then(storeReportService).should(times(1)).createStoreReport(any(), any(), any());
+    }
+
+    @Nested
+    @DisplayName("가게 신고 생성 데이터 검증 실패")
+    class createStoreReportFail {
+
+        @Test
+        @DisplayName("가게 신고 내용이 blank인 경우 예외가 발생한다.")
+        void whenReportContentIsBlank() throws Exception {
+            // given
+            Long storeId = 1L;
+            ReportCreateRequest badReportCreateRequest = new ReportCreateRequest(
+                    "",
+                    new BigDecimal("37.123456"),
+                    new BigDecimal("127.123456")
+            );
+
+
+            // when
+            ResultActions resultActions = performCreateStoreReport(badReportCreateRequest, storeId);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value("content : 신고 내용을 입력해주세요. (request value: )"));
+
+            then(storeReportService).should(never()).createStoreReport(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("가게 신고 내용이 null인 경우 예외가 발생한다.")
+        void whenReportContentIsNull() throws Exception {
+            // given
+            Long storeId = 1L;
+            ReportCreateRequest badReportCreateRequest = new ReportCreateRequest(
+                    null,
+                    new BigDecimal("37.123456"),
+                    new BigDecimal("127.123456")
+            );
+
+
+            // when
+            ResultActions resultActions = performCreateStoreReport(badReportCreateRequest, storeId);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value("content : 신고 내용을 입력해주세요. (request value: null)"));
+
+            then(storeReportService).should(never()).createStoreReport(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("가게 신고 내용이 300자를 초과하는 경우 예외가 발생한다.")
+        void whenReportContentIsOver300() throws Exception {
+            // given
+            Long storeId = 1L;
+            ReportCreateRequest badReportCreateRequest = new ReportCreateRequest(
+                    "가게 신고 내용".repeat(50),
+                    new BigDecimal("37.123456"),
+                    new BigDecimal("127.123456")
+            );
+
+
+            // when
+            ResultActions resultActions = performCreateStoreReport(badReportCreateRequest, storeId);
+
+            // then
+            resultActions
+                    .andExpect(status().isBadRequest());
+        }
+
+    }
+
+    @Test
+    @DisplayName("가게 신고 삭제 성공")
+    void deleteStoreReportSuccess() throws Exception {
+        // given
+        Long reportId = 1L;
+
+        // when
+        ResultActions resultActions = performDeleteStoreReport(reportId);
+
+        // then
+        resultActions
+                .andExpect(status().isNoContent())
+                .andDo(
+                        restDocs.document(
+                                requestHeaders(
+                                        headerWithName(AUTHORIZATION).description("Access Token")
+                                ),
+                                pathParameters(
+                                        parameterWithName("reportId").description("신고 ID")
+                                )
+                        )
+                );
+
+        then(storeReportService).should(times(1)).deleteReport(any(), any());
+    }
+
+    @Test
+    @DisplayName("사용자가 신고했던 가게 리스트 조회")
+    void checkMemberReportList() throws Exception {
+        //given
+        StoreReportHistoryListResponse storeReportHistoryListResponse = StoreReportHistoryListResponse.of(
+                List.of(
+                        new StoreReportHistoryResponse(
+                                1L,
+                                "가게 신고 내용",
+                                new StoreReportMemberResponse(1L, "nickname", "profileImageUrl"),
+                                new StoreReportStoreResponse(1L, "storeName", "storeImageUrl"),
+                                LocalDateTime.of(2021, 10, 1, 0, 0, 0),
+                                LocalDateTime.of(2021, 10, 1, 0, 0, 0)
+                        ),
+                        new StoreReportHistoryResponse(
+                                2L,
+                                "가게 신고 내용",
+                                new StoreReportMemberResponse(1L, "nickname", "profileImageUrl"),
+                                new StoreReportStoreResponse(1L, "storeName", "storeImageUrl"),
+                                LocalDateTime.of(2022, 10, 1, 0, 0, 0),
+                                LocalDateTime.of(2022, 10, 1, 0, 0, 0)
+                        )
+                )
+        );
+
+        given(storeReportService.checkMemberReportList(anyLong())).willReturn(storeReportHistoryListResponse);
+
+        // when
+        ResultActions resultActions = performCheckMemberReportList();
+
+        // then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isOk())
+                .andDo(
+                        restDocs.document(
+                                requestHeaders(
+                                        headerWithName(AUTHORIZATION).description("Access Token")
+                                ),
+                                responseFields(
+                                        fieldWithPath("results[].id")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("신고 ID"),
+                                        fieldWithPath("results[].content")
+                                                .type(JsonFieldType.STRING)
+                                                .description("신고 내용"),
+                                        fieldWithPath("results[].member")
+                                                .type(JsonFieldType.OBJECT)
+                                                .description("신고자 정보"),
+                                        fieldWithPath("results[].member.id")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("신고자 ID"),
+                                        fieldWithPath("results[].member.nickname")
+                                                .type(JsonFieldType.STRING)
+                                                .description("신고자 닉네임"),
+                                        fieldWithPath("results[].member.profileImageUrl")
+                                                .type(JsonFieldType.STRING)
+                                                .description("신고자 프로필 이미지 URL"),
+                                        fieldWithPath("results[].store")
+                                                .type(JsonFieldType.OBJECT)
+                                                .description("가게 정보"),
+                                        fieldWithPath("results[].store.id")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("가게 ID"),
+                                        fieldWithPath("results[].store.name")
+                                                .type(JsonFieldType.STRING)
+                                                .description("가게 이름"),
+                                        fieldWithPath("results[].store.imageUrl")
+                                                .type(JsonFieldType.STRING)
+                                                .description("가게 이미지 URL"),
+                                        fieldWithPath("results[].createdAt")
+                                                .type(JsonFieldType.STRING)
+                                                .description("신고 생성 시간"),
+                                        fieldWithPath("results[].modifiedAt")
+                                                .type(JsonFieldType.STRING)
+                                                .description("신고 수정 시간")
+                                )
+                        )
+                ).andReturn();
+
+        StoreReportHistoryListResponse response = objectMapper.readValue(
+                mvcResult.getResponse().getContentAsString(),
+                StoreReportHistoryListResponse.class
+        );
+
+        assertThat(response).usingRecursiveComparison()
+                .isEqualTo(storeReportHistoryListResponse);
+
+        then(storeReportService).should(times(1)).checkMemberReportList(any());
+    }
+
+    @Test
+    @DisplayName("해당 가게 신고 리스트 조회")
+    void checkStoreReportList() throws Exception {
+        //given
+        Long storeId = 1L;
+        StoreReportHistoryListResponse storeReportHistoryListResponse = StoreReportHistoryListResponse.of(
+                List.of(
+                        new StoreReportHistoryResponse(
+                                1L,
+                                "가게 신고 내용",
+                                new StoreReportMemberResponse(1L, "nickname", "profileImageUrl"),
+                                new StoreReportStoreResponse(1L, "storeName", "storeImageUrl"),
+                                LocalDateTime.of(2021, 10, 1, 0, 0, 0),
+                                LocalDateTime.of(2021, 10, 1, 0, 0, 0)
+                        ),
+                        new StoreReportHistoryResponse(
+                                2L,
+                                "가게 신고 내용",
+                                new StoreReportMemberResponse(1L, "nickname", "profileImageUrl"),
+                                new StoreReportStoreResponse(1L, "storeName", "storeImageUrl"),
+                                LocalDateTime.of(2022, 10, 1, 0, 0, 0),
+                                LocalDateTime.of(2022, 10, 1, 0, 0, 0)
+                        )
+                )
+        );
+
+        given(storeReportService.checkStoreReportList(anyLong())).willReturn(storeReportHistoryListResponse);
+
+        // when
+        ResultActions resultActions = performCheckStoreReportList(storeId);
+
+        // then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isOk())
+                .andDo(
+                        restDocs.document(
+                                pathParameters(
+                                        parameterWithName("storeId").description("가게 ID")
+                                ),
+                                requestHeaders(
+                                        headerWithName(AUTHORIZATION).description("Access Token")
+                                ),
+                                responseFields(
+                                        fieldWithPath("results[].id")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("신고 ID"),
+                                        fieldWithPath("results[].content")
+                                                .type(JsonFieldType.STRING)
+                                                .description("신고 내용"),
+                                        fieldWithPath("results[].member")
+                                                .type(JsonFieldType.OBJECT)
+                                                .description("신고자 정보"),
+                                        fieldWithPath("results[].member.id")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("신고자 ID"),
+                                        fieldWithPath("results[].member.nickname")
+                                                .type(JsonFieldType.STRING)
+                                                .description("신고자 닉네임"),
+                                        fieldWithPath("results[].member.profileImageUrl")
+                                                .type(JsonFieldType.STRING)
+                                                .description("신고자 프로필 이미지 URL"),
+                                        fieldWithPath("results[].store")
+                                                .type(JsonFieldType.OBJECT)
+                                                .description("가게 정보"),
+                                        fieldWithPath("results[].store.id")
+                                                .type(JsonFieldType.NUMBER)
+                                                .description("가게 ID"),
+                                        fieldWithPath("results[].store.name")
+                                                .type(JsonFieldType.STRING)
+                                                .description("가게 이름"),
+                                        fieldWithPath("results[].store.imageUrl")
+                                                .type(JsonFieldType.STRING)
+                                                .description("가게 이미지 URL"),
+                                        fieldWithPath("results[].createdAt")
+                                                .type(JsonFieldType.STRING)
+                                                .description("신고 생성 시간"),
+                                        fieldWithPath("results[].modifiedAt")
+                                                .type(JsonFieldType.STRING)
+                                                .description("신고 수정 시간")
+                                )
+                        )
+                ).andReturn();
+
+        StoreReportHistoryListResponse response = objectMapper.readValue(
+                mvcResult.getResponse().getContentAsString(),
+                StoreReportHistoryListResponse.class
+        );
+
+        assertThat(response).usingRecursiveComparison()
+                .isEqualTo(storeReportHistoryListResponse);
+
+        then(storeReportService).should(times(1)).checkStoreReportList(any());
     }
 
 }


### PR DESCRIPTION
## 🔥 연관 이슈
- close: #401 

## 📝 작업 요약
StoreController 단위 테스트 및 API 문서 작성

## 🔎 작업 상세 설명
1. 가게 신고 생성 API에 대한 성공 및 실패 시나리오에 대한 테스트 작성
2. 가게 신고 삭제 API에 대한 성공 시나리오에 대한 테스트 작성
3. 사용자가 신고했던 가게 리스트 조회 API에 대한 테스트 작성
4. 특정 가게의 신고 리스트 조회 API에 대한 테스트 작성

## 🌟 리뷰 요구 사항

