### PR TITLE
test/#405 가게 신고 서비스 단위 테스트

### DIFF
--- a/src/main/java/com/pd/gilgeorigoreuda/common/exception/ExceptionType.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/common/exception/ExceptionType.java
@@ -27,7 +27,7 @@ public enum ExceptionType {
 	NO_SUCH_PURCHASE_TYPE_EXCEPTION("S003", "존재하지 않는 결제 타입입니다.", NoSuchPurchaseTypeException.class),
 	NO_SUCH_FOOD_TYPE_EXCEPTION("S004", "존재하지 않는 음식 타입입니다.", NoSuchFoodTypeException.class),
 	NO_OWNER_MEMBER_EXCEPTION("S005", "해당 가게의 제보자가 아닙니다.", NoOwnerMemberException.class),
-	NO_REPORTER_MEMBER_EXCEPTION("S006", "해당 가게의 신고자가 아닙니다.", NoRepoterMemberException.class),
+	NO_REPORTER_MEMBER_EXCEPTION("S006", "해당 가게의 신고자가 아닙니다.", NoReporterMemberException.class),
 	ALREADY_EXIST_IN_BOUNDARY_EXCEPTION("S006", "해당 위치에 이미 존재하는 가게가 있습니다.", AlreadyExistInBoundaryException.class),
 
 	OUT_OF_BOUNDARY_EXCEPTION("V001", "인증 가능 범위가 아닙니다.", OutOfBoundaryException.class),

--- a/src/main/java/com/pd/gilgeorigoreuda/store/exception/NoReporterMemberException.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/store/exception/NoReporterMemberException.java
@@ -3,8 +3,8 @@ package com.pd.gilgeorigoreuda.store.exception;
 import com.pd.gilgeorigoreuda.common.exception.GilgeoriGoreudaException;
 import org.springframework.http.HttpStatus;
 
-public class NoRepoterMemberException extends GilgeoriGoreudaException {
-	public NoRepoterMemberException() {
+public class NoReporterMemberException extends GilgeoriGoreudaException {
+	public NoReporterMemberException() {
 		super(HttpStatus.UNAUTHORIZED);
 	}
 }

--- a/src/main/java/com/pd/gilgeorigoreuda/store/service/StoreReportService.java
+++ b/src/main/java/com/pd/gilgeorigoreuda/store/service/StoreReportService.java
@@ -20,7 +20,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class StoreReportService {
 
-    private final StoreReportHistoryRepository storeReportRepository;
+    private final StoreReportHistoryRepository storeReportHistoryRepository;
     private final StoreRepository storeRepository;
     private final DistanceCalculator distanceCalculator;
 
@@ -34,7 +34,7 @@ public class StoreReportService {
 
         checkIsValidDistanceForReport(reportCreateRequest, targetStore);
 
-        storeReportRepository.save(reportCreateRequest.toEntity(storeId, memberId));
+        storeReportHistoryRepository.save(reportCreateRequest.toEntity(storeId, memberId));
     }
 
     @Transactional
@@ -43,12 +43,12 @@ public class StoreReportService {
 
         checkIsReporter(memberId, reportForDelete);
 
-        storeReportRepository.deleteById(reportForDelete.getId());
+        storeReportHistoryRepository.deleteById(reportForDelete.getId());
     }
 
     private static void checkIsReporter(Long memberId, StoreReportHistory reportForDelete) {
         if (!reportForDelete.isReporter(memberId)) {
-            throw new NoRepoterMemberException();
+            throw new NoReporterMemberException();
         }
     }
 
@@ -71,19 +71,19 @@ public class StoreReportService {
     }
 
     private void checkIsExistStoreReportHistory(final Long storeId, final Long memberId) {
-        storeReportRepository.findStoreReportHistoryByStoreIdAndMemberId(storeId, memberId)
+        storeReportHistoryRepository.findStoreReportHistoryByStoreIdAndMemberId(storeId, memberId)
                 .ifPresent(report -> {
                     throw new AlreadyReportedException();
                 });
     }
 
     private StoreReportHistory findStoreReportHistory(final Long reportId) {
-        return storeReportRepository.findStoreReportHistoryByReportId(reportId)
+        return storeReportHistoryRepository.findStoreReportHistoryByReportId(reportId)
                 .orElseThrow(NoSuchReportException::new);
     }
 
     public StoreReportHistoryListResponse checkMemberReportList(final Long memberId){
-        List<StoreReportHistoryResponse> results = storeReportRepository.findStoreReportHistoriesByMemberId(memberId)
+        List<StoreReportHistoryResponse> results = storeReportHistoryRepository.findStoreReportHistoriesByMemberId(memberId)
                 .stream()
                 .map(StoreReportHistoryResponse::of)
                 .toList();
@@ -91,7 +91,7 @@ public class StoreReportService {
         return StoreReportHistoryListResponse.of(results);
     }
     public StoreReportHistoryListResponse checkStoreReportList(final Long storeId){
-        List<StoreReportHistoryResponse> results = storeReportRepository.findStoreReportHistoriesByStoreId(storeId)
+        List<StoreReportHistoryResponse> results = storeReportHistoryRepository.findStoreReportHistoriesByStoreId(storeId)
                 .stream()
                 .map(StoreReportHistoryResponse::of)
                 .toList();

--- a/src/test/java/com/pd/gilgeorigoreuda/settings/ServiceTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/settings/ServiceTest.java
@@ -14,8 +14,10 @@ import com.pd.gilgeorigoreuda.search.repository.SearchRepository;
 import com.pd.gilgeorigoreuda.search.service.SearchService;
 import com.pd.gilgeorigoreuda.store.repository.StoreNativeQueryRepository;
 import com.pd.gilgeorigoreuda.store.repository.StorePreferenceRepository;
+import com.pd.gilgeorigoreuda.store.repository.StoreReportHistoryRepository;
 import com.pd.gilgeorigoreuda.store.repository.StoreRepository;
 import com.pd.gilgeorigoreuda.store.service.StorePreferenceService;
+import com.pd.gilgeorigoreuda.store.service.StoreReportService;
 import com.pd.gilgeorigoreuda.store.service.StoreService;
 import com.pd.gilgeorigoreuda.visit.repository.StoreVisitRecordRepository;
 import com.pd.gilgeorigoreuda.visit.service.VisitService;
@@ -47,6 +49,9 @@ public abstract class ServiceTest {
 
     @InjectMocks
     protected StorePreferenceService storePreferenceService;
+
+    @InjectMocks
+    protected StoreReportService storeReportService;
 
     // Mock 객체
     @Mock
@@ -93,5 +98,8 @@ public abstract class ServiceTest {
 
     @Mock
     protected StorePreferenceRepository storePreferenceRepository;
+
+    @Mock
+    protected StoreReportHistoryRepository storeReportHistoryRepository;
 
 }

--- a/src/test/java/com/pd/gilgeorigoreuda/settings/fixtures/StoreReportHistoryFixtures.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/settings/fixtures/StoreReportHistoryFixtures.java
@@ -1,0 +1,19 @@
+package com.pd.gilgeorigoreuda.settings.fixtures;
+
+import com.pd.gilgeorigoreuda.store.domain.entity.StoreReportHistory;
+
+import static com.pd.gilgeorigoreuda.settings.fixtures.MemberFixtures.*;
+import static com.pd.gilgeorigoreuda.settings.fixtures.StoreFixtures.*;
+
+public class StoreReportHistoryFixtures {
+
+    public static StoreReportHistory BUNGEOPPANG_LEE_REPORT_HISTORY() {
+        return StoreReportHistory.builder()
+                .id(1L)
+                .content("report content")
+                .member(LEE())
+                .store(BUNGEOPPANG())
+                .build();
+    }
+
+}

--- a/src/test/java/com/pd/gilgeorigoreuda/store/service/StoreReportServiceTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/store/service/StoreReportServiceTest.java
@@ -1,0 +1,213 @@
+package com.pd.gilgeorigoreuda.store.service;
+
+import com.pd.gilgeorigoreuda.member.domain.entity.Member;
+import com.pd.gilgeorigoreuda.settings.ServiceTest;
+import com.pd.gilgeorigoreuda.store.domain.entity.Store;
+import com.pd.gilgeorigoreuda.store.domain.entity.StoreReportHistory;
+import com.pd.gilgeorigoreuda.store.dto.request.ReportCreateRequest;
+import com.pd.gilgeorigoreuda.store.exception.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static com.pd.gilgeorigoreuda.settings.fixtures.MemberFixtures.*;
+import static com.pd.gilgeorigoreuda.settings.fixtures.StoreFixtures.*;
+import static com.pd.gilgeorigoreuda.settings.fixtures.StoreReportHistoryFixtures.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+class StoreReportServiceTest extends ServiceTest {
+
+    private static final Integer VALID_BOUNDARY_10M = 10;
+    private static final Integer INVALID_BOUNDARY_200M = 200;
+
+    private ReportCreateRequest makeReportCreateRequest() {
+        return new ReportCreateRequest(
+                "report content",
+                BigDecimal.valueOf(37.123456),
+                BigDecimal.valueOf(127.123456)
+        );
+    }
+
+    @Test
+    @DisplayName("가게 신고 생성 성공 - 가게 신고 이력이 없는 경우, 해당 가게가 존재하는 경우, 유효 거리인 경우")
+    void createStoreReportSuccess() {
+        // given
+        ReportCreateRequest reportCreateRequest = makeReportCreateRequest();
+        Store bungeoppang = BUNGEOPPANG();
+        Member lee = LEE();
+
+        given(storeReportHistoryRepository.findStoreReportHistoryByStoreIdAndMemberId(bungeoppang.getId(), lee.getId()))
+                .willReturn(Optional.empty());
+
+        given(storeRepository.findById(bungeoppang.getId()))
+                .willReturn(Optional.of(bungeoppang));
+
+        given(distanceCalculator.getDistance(
+                reportCreateRequest.getMemberLat(),
+                reportCreateRequest.getMemberLng(),
+                bungeoppang.getLat(),
+                bungeoppang.getLng()
+        )).willReturn(VALID_BOUNDARY_10M);
+
+        // when
+        storeReportService.createStoreReport(reportCreateRequest, bungeoppang.getId(), lee.getId());
+
+        // then
+        then(storeReportHistoryRepository).should(times(1)).findStoreReportHistoryByStoreIdAndMemberId(anyLong(), anyLong());
+        then(storeRepository).should(times(1)).findById(anyLong());
+        then(distanceCalculator).should(times(1)).getDistance(
+                any(BigDecimal.class),
+                any(BigDecimal.class),
+                any(BigDecimal.class),
+                any(BigDecimal.class)
+        );
+        then(storeReportHistoryRepository).should(times(1)).save(any());
+    }
+
+    @Nested
+    @DisplayName("가게 신고 생성 실패 케이스")
+    class createStoreReportFailCases {
+
+        @Test
+        @DisplayName("작성자가 이미 해당 가게 신고 이력이 이미 존재하는 경우")
+        void createStoreReportFailByExistStoreReportHistory() {
+            // given
+            ReportCreateRequest reportCreateRequest = makeReportCreateRequest();
+            Store bungeoppang = BUNGEOPPANG();
+            Member lee = LEE();
+            StoreReportHistory bungeoppang_lee_report_history = BUNGEOPPANG_LEE_REPORT_HISTORY();
+
+
+            given(storeReportHistoryRepository.findStoreReportHistoryByStoreIdAndMemberId(bungeoppang.getId(), lee.getId()))
+                    .willReturn(Optional.of(bungeoppang_lee_report_history));
+
+            // when & then
+            assertThatThrownBy(() -> storeReportService.createStoreReport(reportCreateRequest, bungeoppang.getId(), lee.getId()))
+                    .isInstanceOf(AlreadyReportedException.class)
+                    .extracting("errorCode")
+                    .isEqualTo("R004");
+
+            then(storeReportHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("해당 가게가 존재하지 않는 경우")
+        void createStoreReportFailByNotExistStore() {
+            // given
+            ReportCreateRequest reportCreateRequest = makeReportCreateRequest();
+            Store bungeoppang = BUNGEOPPANG();
+            Member lee = LEE();
+
+            given(storeReportHistoryRepository.findStoreReportHistoryByStoreIdAndMemberId(bungeoppang.getId(), lee.getId()))
+                    .willReturn(Optional.empty());
+
+            given(storeRepository.findById(bungeoppang.getId()))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> storeReportService.createStoreReport(reportCreateRequest, bungeoppang.getId(), lee.getId()))
+                    .isInstanceOf(NoSuchStoreException.class)
+                    .extracting("errorCode")
+                    .isEqualTo("S001");
+
+            then(storeReportHistoryRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("유효 거리가 아닌 경우")
+        void createStoreReportFailByInvalidDistance() {
+            // given
+            ReportCreateRequest reportCreateRequest = makeReportCreateRequest();
+            Store bungeoppang = BUNGEOPPANG();
+            Member lee = LEE();
+
+            given(storeReportHistoryRepository.findStoreReportHistoryByStoreIdAndMemberId(bungeoppang.getId(), lee.getId()))
+                    .willReturn(Optional.empty());
+
+            given(storeRepository.findById(bungeoppang.getId()))
+                    .willReturn(Optional.of(bungeoppang));
+
+            given(distanceCalculator.getDistance(
+                    reportCreateRequest.getMemberLat(),
+                    reportCreateRequest.getMemberLng(),
+                    bungeoppang.getLat(),
+                    bungeoppang.getLng()
+            )).willReturn(INVALID_BOUNDARY_200M);
+
+            // when & then
+            assertThatThrownBy(() -> storeReportService.createStoreReport(reportCreateRequest, bungeoppang.getId(), lee.getId()))
+                    .isInstanceOf(TooLongDistanceToReportException.class)
+                    .extracting("errorCode")
+                    .isEqualTo("R003");
+
+            then(storeReportHistoryRepository).should(never()).save(any());
+        }
+    }
+
+    @Test
+    @DisplayName("가게 신고 삭제 성공 - 해당 신고자가 신고한 경우")
+    void deleteReportSuccess() {
+        // given
+        StoreReportHistory bungeoppang_lee_report_history = BUNGEOPPANG_LEE_REPORT_HISTORY();
+        Member lee = LEE();
+
+        given(storeReportHistoryRepository.findStoreReportHistoryByReportId(bungeoppang_lee_report_history.getId()))
+                .willReturn(Optional.of(bungeoppang_lee_report_history));
+
+        // when
+        storeReportService.deleteReport(bungeoppang_lee_report_history.getId(), lee.getId());
+
+        // then
+        then(storeReportHistoryRepository).should(times(1)).findStoreReportHistoryByReportId(anyLong());
+        then(storeReportHistoryRepository).should(times(1)).deleteById(anyLong());
+    }
+
+    @Nested
+    @DisplayName("가게 신고 삭제 실패 케이스")
+    class deleteReportFailCases {
+
+        @Test
+        @DisplayName("해당 신고자가 신고한 경우가 아닌 경우")
+        void deleteReportFailByNotReporter() {
+            // given
+            StoreReportHistory bungeoppang_lee_report_history = BUNGEOPPANG_LEE_REPORT_HISTORY();
+            Member notReporterMember = KIM();
+
+            given(storeReportHistoryRepository.findStoreReportHistoryByReportId(bungeoppang_lee_report_history.getId()))
+                    .willReturn(Optional.of(bungeoppang_lee_report_history));
+
+            // when & then
+            assertThatThrownBy(() -> storeReportService.deleteReport(bungeoppang_lee_report_history.getId(), notReporterMember.getId()))
+                    .isInstanceOf(NoReporterMemberException.class)
+                    .extracting("errorCode")
+                    .isEqualTo("S006");
+
+            then(storeReportHistoryRepository).should(never()).deleteById(anyLong());
+        }
+
+        @Test
+        @DisplayName("해당 신고 이력이 존재하지 않는 경우")
+        void deleteReportFailByNotExistReport() {
+            // given
+            StoreReportHistory bungeoppang_lee_report_history = BUNGEOPPANG_LEE_REPORT_HISTORY();
+            Member lee = LEE();
+
+            given(storeReportHistoryRepository.findStoreReportHistoryByReportId(bungeoppang_lee_report_history.getId()))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> storeReportService.deleteReport(bungeoppang_lee_report_history.getId(), lee.getId()))
+                    .isInstanceOf(NoSuchReportException.class)
+                    .extracting("errorCode")
+                    .isEqualTo("R002");
+
+            then(storeReportHistoryRepository).should(never()).deleteById(anyLong());
+        }
+
+    }
+
+}


### PR DESCRIPTION
## 🔥 연관 이슈
- close: #405 

## 📝 작업 요약
가게 신고 서비스 단위 테스트 및 예외 테스트

## 🔎 작업 상세 설명
1. 가게 신고 정상 생성 테스트
2. 가게 신고 실패 케이스 테스트
3. 가게 신고 내역 삭제 성공 테스트
4. 가게 신고 내역 삭제 실페 케이스 테스트

## 🌟 리뷰 요구 사항

