### PR TITLE
bug/#410 ReportHistoryRepositoryTest 실패 케이스 수정

### DIFF
--- a/src/test/java/com/pd/gilgeorigoreuda/settings/builder/DataBuilder.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/settings/builder/DataBuilder.java
@@ -76,6 +76,10 @@ public class DataBuilder {
         return builderSupporter.storeReportHistoryRepository().save(storeReportHistory);
     }
 
+    public List<StoreReportHistory> buildStoreReportHistories(final List<StoreReportHistory> storeReportHistories) {
+        return builderSupporter.storeReportHistoryRepository().saveAll(storeReportHistories);
+    }
+
     public Store buildStore(final Store store) {
         return builderSupporter.storeRepository().save(store);
     }

--- a/src/test/java/com/pd/gilgeorigoreuda/settings/fixtures/MemberFixtures.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/settings/fixtures/MemberFixtures.java
@@ -31,7 +31,7 @@ public class MemberFixtures {
                 .id(3L)
                 .nickname("ParkPark")
                 .profileImageUrl("http://image3.com")
-                .socialId("123456789")
+                .socialId("2312323")
                 .memberActiveInfo(PARK_ACTIVE_INFO())
                 .build();
     }

--- a/src/test/java/com/pd/gilgeorigoreuda/settings/fixtures/MemberTokenFixtures.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/settings/fixtures/MemberTokenFixtures.java
@@ -10,7 +10,7 @@ public class MemberTokenFixtures {
         return MemberToken.builder()
                 .memberId(KIM().getId())
                 .accessToken("Kim AccessToken")
-                .refreshToken("Lee RefreshToken")
+                .refreshToken("Kim RefreshToken")
                 .build();
     }
 

--- a/src/test/java/com/pd/gilgeorigoreuda/settings/fixtures/StorePreferenceFixtures.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/settings/fixtures/StorePreferenceFixtures.java
@@ -10,6 +10,7 @@ public class StorePreferenceFixtures {
 
     public static StorePreference BUNGEOPPANG_PREFERENCE_PREFERRED() {
         return StorePreference.builder()
+                .id(1L)
                 .store(BUNGEOPPANG())
                 .member(LEE())
                 .preferenceType(PREFERRED)
@@ -18,6 +19,7 @@ public class StorePreferenceFixtures {
 
     public static StorePreference BUNGEOPPANG_PREFERENCE_NONE() {
         return StorePreference.builder()
+                .id(2L)
                 .store(BUNGEOPPANG())
                 .member(LEE())
                 .preferenceType(NONE)
@@ -26,6 +28,7 @@ public class StorePreferenceFixtures {
 
     public static StorePreference BUNGEOPPANG_PREFERENCE_NOT_PREFERRED() {
         return StorePreference.builder()
+                .id(3L)
                 .store(BUNGEOPPANG())
                 .member(LEE())
                 .preferenceType(NOT_PREFERRED)
@@ -34,6 +37,7 @@ public class StorePreferenceFixtures {
 
     public static StorePreference ODENG_PREFERENCE_PREFERRED() {
         return StorePreference.builder()
+                .id(4L)
                 .store(ODENG())
                 .member(KIM())
                 .preferenceType(PREFERRED)
@@ -42,6 +46,7 @@ public class StorePreferenceFixtures {
 
     public static StorePreference ODENG_PREFERENCE_NONE() {
         return StorePreference.builder()
+                .id(5L)
                 .store(ODENG())
                 .member(KIM())
                 .preferenceType(NONE)
@@ -50,6 +55,7 @@ public class StorePreferenceFixtures {
 
     public static StorePreference ODENG_PREFERENCE_NOT_PREFERRED() {
         return StorePreference.builder()
+                .id(6L)
                 .store(ODENG())
                 .member(KIM())
                 .preferenceType(NOT_PREFERRED)

--- a/src/test/java/com/pd/gilgeorigoreuda/settings/fixtures/StoreReportHistoryFixtures.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/settings/fixtures/StoreReportHistoryFixtures.java
@@ -34,4 +34,13 @@ public class StoreReportHistoryFixtures {
                 .build();
     }
 
+    public static StoreReportHistory BUNGEOPPANG_PARK_REPORT_HISTORY() {
+        return StoreReportHistory.builder()
+                .id(4L)
+                .content("report content")
+                .member(PARK())
+                .store(BUNGEOPPANG())
+                .build();
+    }
+
 }

--- a/src/test/java/com/pd/gilgeorigoreuda/store/repository/StoreReportHistoryRepositoryTest.java
+++ b/src/test/java/com/pd/gilgeorigoreuda/store/repository/StoreReportHistoryRepositoryTest.java
@@ -24,6 +24,7 @@ class StoreReportHistoryRepositoryTest extends RepositoryTest {
         // given
         Member KIM = dataBuilder.buildMember(KIM());
         Member LEE = dataBuilder.buildMember(LEE());
+
         Store BUNGEOPPANG = dataBuilder.buildStore(BUNGEOPPANG());
         StoreReportHistory BUNGEOPPANG_LEE_REPORT_HISTORY = dataBuilder.buildStoreReportHistory(BUNGEOPPANG_LEE_REPORT_HISTORY());
 
@@ -47,60 +48,82 @@ class StoreReportHistoryRepositoryTest extends RepositoryTest {
         Member KIM = dataBuilder.buildMember(KIM());
         Member LEE = dataBuilder.buildMember(LEE());
 
-        Store BUNGEOPPANG = dataBuilder.buildStore(BUNGEOPPANG());
-        Store TTEOKBOKKI = dataBuilder.buildStore(TTEOKBOKKI());
+        dataBuilder.buildStores(List.of(BUNGEOPPANG(), ODENG(), TTEOKBOKKI()));
 
         StoreReportHistory BUNGEOPPANG_LEE_REPORT_HISTORY = dataBuilder.buildStoreReportHistory(BUNGEOPPANG_LEE_REPORT_HISTORY());
+        StoreReportHistory ODENG_KIM_REPORT_HISTORY = dataBuilder.buildStoreReportHistory(ODENG_KIM_REPORT_HISTORY());
         StoreReportHistory TTEOKBOKKI_LEE_REPORT_HISTORY = dataBuilder.buildStoreReportHistory(TTEOKBOKKI_LEE_REPORT_HISTORY());
 
         // when
         List<StoreReportHistory> storeReportHistories = storeReportHistoryRepository.findStoreReportHistoriesByMemberId(LEE.getId());
 
         // then
-        assertThat(storeReportHistories.size()).isEqualTo(2);
+        assertSoftly(
+                softly -> {
+                    softly.assertThat(storeReportHistories.size()).isEqualTo(2);
+                    storeReportHistories.forEach(
+                            storeReportHistory -> softly.assertThat(storeReportHistory.getMember().getId()).isEqualTo(LEE.getId())
+                    );
+                }
+        );
     }
 
     @Test
     @DisplayName("가게 아이디로 해당 가게에 대한 신고들을 조회")
     void findStoreReportHistoriesByStoreId() {
         // given
-        Member KIM = dataBuilder.buildMember(KIM());
-        Member LEE = dataBuilder.buildMember(LEE());
+        dataBuilder.buildMembers(List.of(KIM(), LEE(), PARK()));
 
-        Store BUNGEOPPANG = dataBuilder.buildStore(BUNGEOPPANG());
-        Store TTEOKBOKKI = dataBuilder.buildStore(TTEOKBOKKI());
+        dataBuilder.buildStores(List.of(BUNGEOPPANG(), ODENG(), TTEOKBOKKI()));
 
-        StoreReportHistory BUNGEOPPANG_LEE_REPORT_HISTORY = dataBuilder.buildStoreReportHistory(BUNGEOPPANG_LEE_REPORT_HISTORY());
-        StoreReportHistory TTEOKBOKKI_LEE_REPORT_HISTORY = dataBuilder.buildStoreReportHistory(TTEOKBOKKI_LEE_REPORT_HISTORY());
+        dataBuilder.buildStoreReportHistories(
+                List.of(
+                        BUNGEOPPANG_LEE_REPORT_HISTORY(),
+                        ODENG_KIM_REPORT_HISTORY(),
+                        TTEOKBOKKI_LEE_REPORT_HISTORY(),
+                        BUNGEOPPANG_PARK_REPORT_HISTORY()
+                )
+        );
 
         // when
-        List<StoreReportHistory> storeReportHistories = storeReportHistoryRepository.findStoreReportHistoriesByStoreId(BUNGEOPPANG.getId());
+        List<StoreReportHistory> storeReportHistories = storeReportHistoryRepository.findStoreReportHistoriesByStoreId(BUNGEOPPANG().getId());
 
         // then
-        assertThat(storeReportHistories.size()).isEqualTo(1);
+        assertSoftly(
+                softly -> {
+                    softly.assertThat(storeReportHistories.size()).isEqualTo(2);
+                    storeReportHistories.forEach(
+                            storeReportHistory -> softly.assertThat(storeReportHistory.getStore().getId()).isEqualTo(BUNGEOPPANG().getId())
+                    );
+                }
+        );
     }
 
     @Test
     @DisplayName("가게 아이디와 회원 아이디로 해당 가게에 대한 회원의 신고를 조회")
     void findStoreReportHistoryByStoreIdAndMemberId() {
         // given
-        Member KIM = dataBuilder.buildMember(KIM());
-        Member LEE = dataBuilder.buildMember(LEE());
+        dataBuilder.buildMembers(List.of(KIM(), LEE(), PARK()));
 
-        Store BUNGEOPPANG = dataBuilder.buildStore(BUNGEOPPANG());
-        Store TTEOKBOKKI = dataBuilder.buildStore(TTEOKBOKKI());
+        dataBuilder.buildStores(List.of(BUNGEOPPANG(), ODENG(), TTEOKBOKKI()));
 
-        StoreReportHistory BUNGEOPPANG_LEE_REPORT_HISTORY = dataBuilder.buildStoreReportHistory(BUNGEOPPANG_LEE_REPORT_HISTORY());
-        StoreReportHistory TTEOKBOKKI_LEE_REPORT_HISTORY = dataBuilder.buildStoreReportHistory(TTEOKBOKKI_LEE_REPORT_HISTORY());
+        dataBuilder.buildStoreReportHistories(
+                List.of(
+                        BUNGEOPPANG_LEE_REPORT_HISTORY(),
+                        ODENG_KIM_REPORT_HISTORY(),
+                        TTEOKBOKKI_LEE_REPORT_HISTORY(),
+                        BUNGEOPPANG_PARK_REPORT_HISTORY()
+                )
+        );
 
         // when
-        StoreReportHistory storeReportHistory = storeReportHistoryRepository.findStoreReportHistoryByStoreIdAndMemberId(BUNGEOPPANG.getId(), LEE.getId()).get();
+        StoreReportHistory storeReportHistory = storeReportHistoryRepository.findStoreReportHistoryByStoreIdAndMemberId(BUNGEOPPANG().getId(), LEE().getId()).get();
 
         // then
         assertSoftly(
                 softly -> {
-                    softly.assertThat(storeReportHistory.getStore().getId()).isEqualTo(BUNGEOPPANG.getId());
-                    softly.assertThat(storeReportHistory.getMember().getId()).isEqualTo(LEE.getId());
+                    softly.assertThat(storeReportHistory.getStore().getId()).isEqualTo(BUNGEOPPANG().getId());
+                    softly.assertThat(storeReportHistory.getMember().getId()).isEqualTo(LEE().getId());
                 }
         );
     }


### PR DESCRIPTION
## 🔥 연관 이슈
- close: #410

## 📝 작업 요약
1. StoreReportHistoryRepositoryTest 실패 케이스 수정
2. DataFixtures 수정

## 🔎 작업 상세 설명
DataFixtures를 수정하기에는 너무 많은 변경 코드 발생해서 DataFixtures에 명시되어 있는 id값 순서에 유념하여 저장 후 테스트 실행

## 🌟 리뷰 요구 사항

